### PR TITLE
Ex13 Config Toggle

### DIFF
--- a/Documentation/New-PSNowModule.md
+++ b/Documentation/New-PSNowModule.md
@@ -23,6 +23,15 @@ It runs on PSCore and all supported platforms.
 
 ## EXAMPLES
 
+## Safe Mode Toggle
+
+You can control whether the module path output is shown after creation using the environment variable `PSNOW_SAFE_MODE`.
+
+- If `PSNOW_SAFE_MODE` is set to a truthy value (`1`, `true`, `yes`, or `on`), the output message with the module path is suppressed.
+- If it is not set, or set to a non-truthy value (for example `0`), the output message is shown as normal.
+
+This is a simple safety toggle to reduce risk in automation or scripting scenarios.
+
 ### EXAMPLE 1
 ```
 New-PSNowModule -NewModuleName "MyFabModule" -BaseManifest basic

--- a/Public/New-PSNowModule.ps1
+++ b/Public/New-PSNowModule.ps1
@@ -230,7 +230,12 @@ function New-PSNowModule {
         $NewModuleName = $NewModuleName -replace '.ps1', ''
         $Path = $($ModuleRoot + $env:BHPathDivider + $NewModuleName)
         Set-Location -Path $Path
-        Write-Output "`nYour module was built at: [$Path]`n"
+        # Safe toggle: PSNOW_SAFE_MODE suppresses path output when set to a truthy value.
+        $safeModeValue = [string]$env:PSNOW_SAFE_MODE
+        $safeModeEnabled = $safeModeValue -match '^(1|true|yes|on)$'
+        if (-not $safeModeEnabled) {
+            Write-Output "`nYour module was built at: [$Path]`n"
+        }
 
         $doc = $($templateroot + $env:BHPathDivider + "currentmodules.txt")
         if (-not (Test-Path -Path $doc)) {

--- a/tests/Unit/New-PSNowModule.SafeToggle.tests.ps1
+++ b/tests/Unit/New-PSNowModule.SafeToggle.tests.ps1
@@ -1,0 +1,82 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$moduleManifestCandidates = @(
+    (Join-Path $repoRoot 'PSNow.psd1')
+    (Join-Path $repoRoot 'Staging' 'PSNow' 'PSNow.psd1')
+)
+$moduleManifestPath = $moduleManifestCandidates | Where-Object { Test-Path -Path $_ } | Select-Object -First 1
+
+Remove-Module -Name PSNow -Force -ErrorAction SilentlyContinue
+if (-not [string]::IsNullOrWhiteSpace($moduleManifestPath)) {
+    Import-Module -Name $moduleManifestPath -Force -ErrorAction Stop
+}
+
+InModuleScope -ModuleName PSNow {
+    Describe 'New-PSNowModule safe toggle' {
+        BeforeEach {
+            Remove-Item Env:PSNOW_SAFE_MODE -ErrorAction SilentlyContinue
+            $env:BHPathDivider = [System.IO.Path]::DirectorySeparatorChar
+
+            Mock Get-Variable -ParameterFilter { $Name -eq 'PSVersionTable' -and $ValueOnly } -MockWith {
+                @{ PSVersion = [Version]'5.1.0' }
+            }
+
+            Mock Set-Location {}
+            Mock Test-Path { $true }
+            Mock Remove-Item {}
+            Mock Get-ChildItem { [pscustomobject]@{ FullName = 'C:\localrepo\PSNow\PlasterTemplate\Basic.xml' } }
+            Mock New-Item {}
+            Mock Add-Content {}
+            Mock Copy-Item {}
+            Mock Write-Verbose {}
+            Mock Invoke-Plaster {
+                param(
+                    [string]$TemplatePath,
+                    [string]$Destination,
+                    [string]$ModuleName,
+                    [string]$GitHubUserName,
+                    [string]$PowerShellVersion,
+                    [switch]$Force,
+                    [switch]$Verbose
+                )
+
+                [void]$TemplatePath
+                [void]$Destination
+                [void]$ModuleName
+                [void]$GitHubUserName
+                [void]$PowerShellVersion
+                [void]$Force
+                [void]$Verbose
+            }
+
+            Mock Write-Output {}
+        }
+
+        AfterEach {
+            Remove-Item Env:PSNOW_SAFE_MODE -ErrorAction SilentlyContinue
+        }
+
+        It 'writes module path output when safe mode is OFF' {
+            $null = New-PSNowModule -NewModuleName 'SafeOff' -BaseManifest 'Basic' -ModuleRoot 'c:\modules'
+
+            Should -Invoke Write-Output -ParameterFilter { $InputObject -match 'Your module was built at:' } -Exactly 1 -Scope It
+        }
+
+        It 'suppresses module path output when safe mode is ON' {
+            $env:PSNOW_SAFE_MODE = '1'
+
+            $null = New-PSNowModule -NewModuleName 'SafeOn' -BaseManifest 'Basic' -ModuleRoot 'c:\modules'
+
+            Should -Invoke Write-Output -ParameterFilter { $InputObject -match 'Your module was built at:' } -Exactly 0 -Scope It
+        }
+
+        It 'writes module path output when safe mode is explicitly OFF' {
+            $env:PSNOW_SAFE_MODE = '0'
+
+            $null = New-PSNowModule -NewModuleName 'SafeZero' -BaseManifest 'Basic' -ModuleRoot 'c:\modules'
+
+            Should -Invoke Write-Output -ParameterFilter { $InputObject -match 'Your module was built at:' } -Exactly 1 -Scope It
+        }
+    }
+}


### PR DESCRIPTION
We added a safe mode toggle into the mix. You can control whether the module path output is shown after creation using the environment variable `PSNOW_SAFE_MODE`.
