### PR TITLE
GHCP -- Walk: ex4 CONTRIBUTING and onboarding docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,196 @@
+# Contributing to PSNow
+
+Thank you for contributing! This document covers the branching strategy, PR expectations, and how to work with GitHub Copilot on this project.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Branching Strategy](#branching-strategy)
+- [Development Workflow](#development-workflow)
+- [PR Expectations](#pr-expectations)
+- [Using GitHub Copilot](#using-github-copilot)
+- [Walk Track Workflow](#walk-track-workflow)
+- [Validation](#validation)
+- [Code Conventions](#code-conventions)
+
+---
+
+## Prerequisites
+
+1. **PowerShell 7+** — all scripts target PS Core.
+2. **Required modules** — install once from the repo root:
+   ```powershell
+   ./Build/Build.ps1 -ResolveDependency
+   ```
+3. **Environment variables** — add to your PowerShell profile:
+   ```powershell
+   Set-Item -Path Env:BHGitHubUser       -Value '<your GitHub username>'
+   Set-Item -Path Env:BHPSGalleryKey     -Value '<PS Gallery key>'
+   Set-Item -Path Env:BHAzureBuildUser   -Value '<Azure build user>'
+   Set-Item -Path Env:BHAzureBuildPassword -Value '<Azure token>'
+   Set-Item -Path Env:BHAzureRepoUrl     -Value '<Azure Artifacts feed URL>'
+   ```
+
+---
+
+## Branching Strategy
+
+| Branch pattern | Purpose |
+|---|---|
+| `main` | Stable, always green. PRs merge here. |
+| `walk-ex<N>` | One branch per Walk-track exercise (e.g., `walk-ex3`) |
+| `crawl-ex<N>` | One branch per Crawl-track exercise |
+| `run-ex<N>` | One branch per Run-track exercise |
+
+**Rules:**
+- Branch from the tip of the previous exercise branch (or `main` after it merges).
+- Keep branches small — one exercise, one PR.
+- Never commit directly to `main`.
+
+```powershell
+git checkout main && git pull
+git checkout -b walk-ex5
+```
+
+---
+
+## Development Workflow
+
+1. **Plan first** — identify the goal and list the files you will touch before writing any code.
+2. **Make changes** — implement file by file; review each diff before moving on.
+3. **Validate locally** — always run the full validate script before pushing:
+   ```powershell
+   ./scripts/validate.ps1
+   ```
+   Expected output: `Tests Passed: N, Failed: 0`.
+4. **Commit with intent** — write a commit message that explains *what* and *why*.
+5. **Open a PR** — use the PR template described below.
+
+---
+
+## PR Expectations
+
+Every PR must include the following sections. Use the template below as your PR body:
+
+```
+## Summary
+- What changed and why
+- Plan: <inline summary or link>
+- Files/paths touched
+
+## Evidence
+- Tests/logs/metrics: <commands + output summary>
+- Coverage: <percentage or contract evidence>
+
+## Risk & Rollback
+- Risk: low/medium/high
+- Rollback: revert <commit SHA> or toggle <flag>
+
+## Review Focus
+- Key areas for reviewer attention
+- Verification steps the reviewer can run
+
+## Track
+- Level: Walk
+- Exercise: ex<N>
+```
+
+**Evidence is mandatory.** Paste the test result line from `validate.ps1`:
+```
+Tests Passed: 266, Failed: 0, Skipped: 4
+```
+
+---
+
+## Using GitHub Copilot
+
+PSNow uses a **plan-first, evidence-backed** workflow with Copilot:
+
+### Starting a task
+1. Describe the goal to Copilot in plain English.
+2. Ask Copilot to **write a plan** (files to change, reason, expected impact) before touching any code.
+3. Review the plan. Ask Copilot to adjust scope if it touches more than 4 files.
+
+### Reviewing diffs
+- Ask Copilot to generate changes **file by file**.
+- Review each diff before accepting — don't bulk-accept.
+- If a change looks wrong, say so: "That will break X because Y. Try Z instead."
+
+### After changes
+- Run `./scripts/validate.ps1` and paste the output summary back to Copilot.
+- If tests fail, share the failure output and ask Copilot to diagnose before reverting.
+
+### Useful prompts
+```
+"Write a plan for [task]. List each file, the reason for changing it, and expected impact. Stay under 4 files."
+
+"Generate the diff for [filename] only. I'll review before moving to the next file."
+
+"The validate script failed with this error: [paste]. What caused it and how do I fix it?"
+```
+
+---
+
+## Walk Track Workflow
+
+The Walk track builds on Crawl by introducing plan-first development, evidence-backed PRs, and Copilot-assisted refactoring. Each exercise follows this cycle:
+
+```
+Plan → Implement → Validate → PR
+```
+
+### Exercise naming
+- Branch: `walk-ex<N>`
+- PR title: `GHCP -- Walk: ex<N> <short description>`
+
+### What "plan-first" means
+Before writing code, produce a short written plan that answers:
+- What files will change?
+- Why is each change needed?
+- What is the expected impact (behaviour, tests, lines changed)?
+
+Include this plan verbatim in the PR description under `## Summary`.
+
+### Evidence requirements
+- Run `./scripts/validate.ps1` — paste the `Tests Passed` line.
+- For coverage exercises, run `./scripts/run-coverage.ps1` — paste the `Total coverage` line and attach `BuildOutput/coverage-summary.txt`.
+
+### Keeping scope small
+If a refactor touches more than 4 files, narrow it. The smallest meaningful change is always preferred over the most complete one.
+
+---
+
+## Validation
+
+The single entry point for all local validation is:
+
+```powershell
+./scripts/validate.ps1
+```
+
+This runs (in order): dependency resolution → init → stage → PSScriptAnalyzer → Pester tests → architecture diagram render.
+
+Individual tasks can also be run via the build system:
+
+```powershell
+./Build/build.ps1 -TaskList stage
+./Build/build.ps1 -TaskList analyze
+./Build/build.ps1 -TaskList test
+./Build/build.ps1 -TaskList analyze,test
+```
+
+CI runs the same pipeline on both **Windows** and **Ubuntu** via Azure Pipelines (`azure-pipelines.yml`). A PR is not mergeable until both matrix legs are green.
+
+---
+
+## Code Conventions
+
+See `.github/copilot-instructions.md` for the full reference. Key rules:
+
+- **One file per function** in `Public/` and `Private/`.
+- **Private helpers** use a `PSNow` noun prefix (e.g., `Get-PSNowTempDirectory`).
+- **Paths** — always use `Join-Path`; never hardcode `\` or `/`.
+- **PSScriptAnalyzer** — the build fails on `Error` severity. Add `SuppressMessageAttribute` only when the rule genuinely doesn't apply, and comment why.
+- **Tests** — unit tests live in `tests/Unit/<FunctionName>.tests.ps1`. Add a test for every new public function.

--- a/Documentation/onboarding-walk.md
+++ b/Documentation/onboarding-walk.md
@@ -1,0 +1,133 @@
+# PSNow — Walk Track Onboarding Prompt
+
+> **How to use this file:** Paste the contents of the "Copilot Chat Prompt" section below directly into a GitHub Copilot Chat window (or any Copilot-enabled IDE chat). It gives Copilot everything it needs to orient itself to the project and assist you with Walk-track exercises.
+
+---
+
+## Copilot Chat Prompt
+
+```
+You are helping me work on the PSNow repository (github.com/johnmccrae/PSNow).
+
+## What PSNow is
+PSNow is a PowerShell scaffolding module. Its primary exported function, New-PSNowModule,
+invokes Plaster with one of three template manifests (Basic, Extended, Advanced) to generate
+a fully structured PowerShell module at a user-specified destination path.
+
+## Project layout
+- Public/          — one .ps1 per exported function (auto-exported by PSNow.psm1)
+- Private/         — internal helpers, not exported; use PSNow noun prefix
+- tests/Unit/      — Pester unit tests, named <FunctionName>.tests.ps1
+- tests/Acceptance/— PSScriptAnalyzer + parse checks run against Staging/
+- tests/Common/    — shared tests (manifest, help, environment, basic)
+- tests/Integration/— full Plaster invocation tests
+- Build/           — PSake tasks (build.psake.ps1), dependency manifest, PSSA settings
+- PlasterTemplate/ — Basic.xml, Extended.xml, Advanced.xml Plaster manifests
+- scripts/         — helper scripts (validate.ps1, run-coverage.ps1, etc.)
+- Documentation/   — function reference docs and onboarding guides (here)
+
+## How to validate (always run before pushing)
+./scripts/validate.ps1
+# Expect: Tests Passed: N, Failed: 0, exit code 0
+
+## How to run coverage
+./scripts/run-coverage.ps1
+# Expect: [coverage] Total coverage: N.NN%
+
+## Individual build tasks
+./Build/build.ps1 -TaskList stage        # stage module to Staging/PSNow/
+./Build/build.ps1 -TaskList analyze      # run PSScriptAnalyzer
+./Build/build.ps1 -TaskList test         # run Pester
+./Build/build.ps1 -TaskList analyze,test # lint + test together
+
+## CI
+Azure Pipelines runs against Windows and Ubuntu. Both must be green for a PR to merge.
+Config: azure-pipelines.yml
+
+## Key conventions
+- Always use Join-Path for path construction (never hardcode \ or /)
+- PSScriptAnalyzer errors fail the build; suppress only when genuinely inapplicable
+- Verbs that change state (New-, Set-, Remove-) need SuppressMessageAttribute or ShouldProcess
+- Private helpers use indirection pattern (Get-Variable instead of $PSVersionTable) so they can be mocked
+
+## Walk track workflow
+I am working on the Walk track of the GitHub Copilot training curriculum.
+Each exercise follows: Plan → Implement → Validate → PR.
+
+Rules:
+- Write a plan (files, reason, impact) BEFORE touching code
+- Generate diffs file by file; I review each before accepting
+- Never touch more than 4 files per exercise
+- Every PR includes: plan, test evidence (paste from validate.ps1), risk, rollback
+
+## Current exercise
+[REPLACE THIS LINE with the exercise description before pasting]
+```
+
+---
+
+## Quick Reference
+
+### Branch and PR naming
+```powershell
+git checkout -b walk-ex<N>
+# PR title: "GHCP -- Walk: ex<N> <short description>"
+```
+
+### Validate before every push
+```powershell
+./scripts/validate.ps1          # full pipeline
+./scripts/run-coverage.ps1      # coverage report (writes BuildOutput/coverage-summary.txt)
+```
+
+### PR body sections (required)
+| Section | What to include |
+|---|---|
+| **Summary** | What changed, why, files touched |
+| **Evidence** | `Tests Passed: N, Failed: 0` from validate output |
+| **Risk & Rollback** | Risk level + `git revert <SHA>` |
+| **Review Focus** | What the reviewer should check + verification commands |
+| **Track** | Level: Walk, Exercise: ex\<N\> |
+
+### Common Copilot prompts for Walk exercises
+
+**Starting a task:**
+> "Write a plan for [goal]. List each file to change, the reason, and expected impact. Keep scope to 4 files or fewer."
+
+**Reviewing a diff:**
+> "Show me only the diff for [filename]. I'll review before moving to the next file."
+
+**Diagnosing a failure:**
+> "The validate script failed with this error: [paste output]. What caused it and how do I fix it without reverting?"
+
+**Writing a PR:**
+> "Write the PR body for this change using the PSNow PR template. Include the plan inline and the test evidence: Tests Passed: N, Failed: 0."
+
+---
+
+## Environment Setup
+
+First-time setup — run once from the repo root:
+
+```powershell
+./Build/Build.ps1 -ResolveDependency
+```
+
+Profile variables (add to `$PROFILE`):
+
+```powershell
+Set-Item -Path Env:BHGitHubUser         -Value '<your GitHub username>'
+Set-Item -Path Env:BHPSGalleryKey       -Value '<PS Gallery key>'
+Set-Item -Path Env:BHAzureBuildUser     -Value '<Azure build user>'
+Set-Item -Path Env:BHAzureBuildPassword -Value '<Azure token>'
+Set-Item -Path Env:BHAzureRepoUrl       -Value '<Azure Artifacts feed URL>'
+```
+
+---
+
+## Further Reading
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — full contribution guide
+- [`.github/copilot-instructions.md`](../.github/copilot-instructions.md) — Copilot context file (architecture, conventions, build commands)
+- [`ai-track-docs/SYSTEM-OVERVIEW.md`](../ai-track-docs/SYSTEM-OVERVIEW.md) — system architecture overview
+- [`ai-track-docs/build-test.md`](../ai-track-docs/build-test.md) — build and test deep-dive

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,11 @@ Follow the directions below to get started. The process will ask you some basic 
 
 The New-PSNowModule function uses Plaster to create a robust, fully built out, but empty, module structure. You'll then create your functions and use build.ps1 for everything else. Open build.ps1 and read the comments in the header. The comments will give you an idea of everything you can do with it. Individual build tasks are defined in build.psake.ps1. You can interrogate that file to add your own tweaks.
 
+## Contributing & Onboarding
+
+- [**CONTRIBUTING.md**](CONTRIBUTING.md) — branching strategy, PR expectations, and how to use Copilot with this project.
+- [**Walk Track Onboarding**](Documentation/onboarding-walk.md) — paste-ready Copilot Chat prompt and quick reference for Walk-track exercises.
+
 ## Getting Started
 
 ### Install from the PSGallery and Import the module


### PR DESCRIPTION
## Summary
- **What changed**: Created `CONTRIBUTING.md`, added `Documentation/onboarding-walk.md`, and linked both from `readme.md`.
- **Why**: No contribution guide existed. New contributors had no documented branching strategy, PR expectations, or guidance on using Copilot with the plan-first workflow this track uses.
- **Plan**: Inline below.
- **Files/paths touched**:
  - `CONTRIBUTING.md` (new)
  - `Documentation/onboarding-walk.md` (new)
  - `readme.md` (updated — added Contributing & Onboarding section)

---

## Plan

### Gap analysis
| Gap | Resolution |
|---|---|
| No branching strategy documented | Added branch naming table (`walk-ex<N>`, `crawl-ex<N>`, `run-ex<N>`) and rules in CONTRIBUTING |
| No PR template or evidence requirements | Added full PR template and mandatory evidence section in CONTRIBUTING |
| No Copilot workflow guidance | Added plan-first + file-by-file diff review section with example prompts |
| No onboarding entry point for new contributors | Created `Documentation/onboarding-walk.md` as a paste-ready Copilot Chat prompt |
| README had no link to contribution docs | Added `## Contributing & Onboarding` section with direct links |

### File-by-file rationale
**`CONTRIBUTING.md`** — covers: prerequisites, branching strategy, dev workflow, PR expectations (with template), Copilot usage guide (prompts, diff review process), Walk track workflow, validation instructions, and code conventions.

**`Documentation/onboarding-walk.md`** — a self-contained file a new developer can paste into Copilot Chat. Includes project layout, build commands, CI context, key conventions, and the plan-first rules — all in a single prompt block. Also includes a quick-reference table and environment setup guide.

**`readme.md`** — added a `## Contributing & Onboarding` section at the top of the content area, linking both new files.

---

## Evidence
- **Validate**: `./scripts/validate.ps1` — exit code 0
- **Tests**: 266 passed, 0 failed, 4 skipped (documentation changes do not affect test count)

```
Tests completed in 46.65s
Tests Passed: 266, Failed: 0, Skipped: 4, Inconclusive: 0, NotRun: 0
psake succeeded
```

## Risk & Rollback
- **Risk**: Low — documentation only; no code changed.
- **Rollback**: `git revert f252a44`

## Review Focus
- Check that the PR template in `CONTRIBUTING.md` matches the template used in PRs #18 and #19.
- Check that `Documentation/onboarding-walk.md` prompt block is accurate for the current repo state.
- Verify readme links resolve correctly on GitHub.

## Track
- **Level**: Walk
- **Exercise**: ex4