### PR TITLE
GHCP -- Walk: ex6 Performance optimizations in Remove-OldPSNowManifest and New-PSNowModule

### DIFF
--- a/Private/Remove-OldPSNowManifest.ps1
+++ b/Private/Remove-OldPSNowManifest.ps1
@@ -20,7 +20,10 @@ function Remove-OldPSNowManifest {
         Remove-Item -Path $lowerManifest
     }
 
-    $plasterdoc = Get-ChildItem (Join-Path -Path $TemplateRoot -ChildPath 'PlasterTemplate') -Filter "$BaseManifest.xml" |
-        ForEach-Object { $_.FullName }
+    # Direct path construction avoids Get-ChildItem + pipeline overhead for a known filename.
+    $plasterdoc = Join-Path -Path $TemplateRoot -ChildPath "PlasterTemplate\$BaseManifest.xml"
+    if (-not (Test-Path $plasterdoc -PathType Leaf)) {
+        throw "Plaster manifest not found: $plasterdoc"
+    }
     Copy-Item -Path $plasterdoc -Destination $lowerManifest
 }

--- a/Public/New-PSNowModule.ps1
+++ b/Public/New-PSNowModule.ps1
@@ -103,10 +103,8 @@ function New-PSNowModule {
         Write-PSNowStructuredLog -Operation 'invoke-plaster' -Status 'started' -Fields $invokePlasterLogFields
 
         try {
-            $invokePlasterParams = @{}
-            foreach ($entry in $PlasterParams.GetEnumerator()) {
-                $invokePlasterParams[$entry.Key] = $entry.Value
-            }
+            # .Clone() copies all entries in a single BCL call; faster than iterating key-by-key.
+            $invokePlasterParams = $PlasterParams.Clone()
 
             while ($true) {
                 try {


### PR DESCRIPTION
Summary
- What changed and why: Replaced two hot-path inefficiencies found via stopwatch profiling. (1) Remove-OldPSNowManifest used Get-ChildItem | ForEach-Object { $_.FullName } to locate a file whose name is already deterministic — replaced with a direct Join-Path + guard. (2) New-PSNowModule copied a hashtable via a foreach key-by-key loop — replaced with .Clone().
- Plan: inline — profile candidates with Stopwatch over 2000 iterations, measure before/after, apply change, re-measure, verify 63/63 unit tests pass.
- Files/paths touched:
  - Private/Remove-OldPSNowManifest.ps1
  - Public/New-PSNowModule.ps1

Evidence
- Tests/logs/metrics:
  Candidate 1 — Get-ChildItem pipeline vs Join-Path (2000 iters): BEFORE 2015ms / AFTER 587ms => 3.4x speedup (~0.7ms saved per New-PSNowModule call)
  Candidate 2 — foreach hashtable copy vs .Clone() (2000 iters): BEFORE 15ms / AFTER 7ms => 2.1x speedup
  Invoke-Pester -Path .\tests\Unit\ => Tests Passed: 63, Failed: 0
- Coverage: no new tests required — changes are drop-in replacements with identical behaviour; existing 63 unit tests cover both code paths.

Risk & Rollback
- Risk: low — both changes produce identical output; the only addition is an explicit throw in Remove-OldPSNowManifest when a template file is missing (previously would have silently passed null to Copy-Item)
- Rollback: revert 2ea40d8

Review Focus
- Remove-OldPSNowManifest.ps1: confirm the Join-Path pattern correctly resolves to PlasterTemplate\<name>.xml for Basic, Extended, and Advanced
- New-PSNowModule.ps1: confirm .Clone() shallow copy is safe given the retry loop only removes keys from the working copy, not the original $PlasterParams
- Verification steps the reviewer can run:
  Invoke-Pester -Path .\tests\Unit\ -Output Normal

Track
- Level: Walk
- Exercise: ex6