### PR TITLE
GHCP -- Walk: ex10 Advisory CI Coverage Summary

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,3 +83,13 @@ steps:
     errorActionPreference: 'stop'
     failOnStderr: false
     pwsh: true
+
+- task: PowerShell@2
+  displayName: Coverage summary (advisory)
+  continueOnError: true
+  inputs:
+    targetType: 'filePath'
+    filePath: ./scripts/Write-CoverageSummary.ps1
+    errorActionPreference: 'continue'
+    failOnStderr: false
+    pwsh: true

--- a/scripts/Write-CoverageSummary.ps1
+++ b/scripts/Write-CoverageSummary.ps1
@@ -1,0 +1,91 @@
+<#
+.SYNOPSIS
+Runs Pester with code coverage and writes an advisory markdown summary
+to the Azure Pipelines job summary (##vso[task.uploadsummary]).
+
+.NOTES
+This script is intentionally non-blocking: any failure exits with code 0
+so it cannot prevent a merge.
+#>
+[CmdletBinding()]
+param(
+    [string]$ProjectRoot = $env:BHProjectPath,
+    [string]$StagingPath = (Join-Path $env:BHProjectPath 'Staging' $env:BHProjectName)
+)
+
+try {
+    $testScripts = @(
+        Get-ChildItem (Join-Path $ProjectRoot 'tests' '**' '*Tests.ps1') -ErrorAction SilentlyContinue
+    )
+
+    $sourceFiles = @(
+        Get-ChildItem (Join-Path $StagingPath 'Public'  '*.ps1') -ErrorAction SilentlyContinue
+        Get-ChildItem (Join-Path $StagingPath 'Private' '*.ps1') -ErrorAction SilentlyContinue
+    )
+
+    if ($testScripts.Count -eq 0 -or $sourceFiles.Count -eq 0) {
+        Write-Warning 'Coverage summary skipped: no test scripts or source files found.'
+        exit 0
+    }
+
+    $config = New-PesterConfiguration
+    $config.Run.Path             = [string[]]$testScripts.FullName
+    $config.Run.PassThru         = $true
+    $config.CodeCoverage.Enabled = $true
+    $config.CodeCoverage.Path    = [string[]]$sourceFiles.FullName
+    $config.Output.Verbosity     = 'None'
+
+    $result = Invoke-Pester -Configuration $config
+
+    $cov     = $result.CodeCoverage
+    $pct     = if ($cov.CommandsAnalyzedCount -gt 0) {
+        [math]::Round(($cov.CommandsExecutedCount / $cov.CommandsAnalyzedCount) * 100, 1)
+    } else { 0 }
+
+    $passed  = $result.PassedCount
+    $failed  = $result.FailedCount
+    $total   = $result.TotalCount
+    $elapsed = [math]::Round($result.Duration.TotalSeconds, 1)
+
+    # Build markdown
+    $badge = if ($pct -ge 80) { '🟢' } elseif ($pct -ge 60) { '🟡' } else { '🔴' }
+
+    $md = @"
+# $badge PSNow CI Summary
+
+| Metric | Value |
+|--------|-------|
+| Tests passed | $passed / $total |
+| Tests failed | $failed |
+| Code coverage | $pct% ($($cov.CommandsExecutedCount) / $($cov.CommandsAnalyzedCount) commands) |
+| Duration | ${elapsed}s |
+| Agent OS | $(if ($env:AGENT_OS) { $env:AGENT_OS } elseif ($IsWindows) { 'Windows_NT' } else { 'Linux' }) |
+| Branch | $(if ($env:BUILD_SOURCEBRANCH) { $env:BUILD_SOURCEBRANCH } else { $env:BHBranchName }) |
+| Build | $(if ($env:BUILD_BUILDNUMBER) { $env:BUILD_BUILDNUMBER } else { $env:BHBuildNumber }) |
+
+> **Advisory only** — this summary does not block merges.
+"@
+
+    if ($cov.CommandsMissedCount -gt 0) {
+        $missedCmds = $cov.CommandsMissed | Select-Object -First 10
+        $md += "`n`n## Missed Commands (top 10)`n`n| File | Line | Command |`n|------|------|---------|`n"
+        foreach ($cmd in $missedCmds) {
+            $file = Split-Path $cmd.File -Leaf
+            $md  += "| $file | $($cmd.Line) | ``$($cmd.Text -replace '\|','&#124;')`` |`n"
+        }
+    }
+
+    $summaryFile = Join-Path ([System.IO.Path]::GetTempPath()) 'psnow-ci-summary.md'
+    $md | Out-File -FilePath $summaryFile -Encoding utf8 -Force
+
+    # Upload to Azure Pipelines job summary
+    Write-Host "##vso[task.uploadsummary]$summaryFile"
+
+    Write-Host "`nCoverage summary written: $pct% ($passed/$total tests passed)"
+}
+catch {
+    Write-Warning "Coverage summary step encountered an error: $_"
+}
+
+# Always exit 0 — this step is advisory only
+exit 0

--- a/scripts/Write-CoverageSummary.ps1
+++ b/scripts/Write-CoverageSummary.ps1
@@ -79,9 +79,9 @@ try {
     $md | Out-File -FilePath $summaryFile -Encoding utf8 -Force
 
     # Upload to Azure Pipelines job summary
-    Write-Host "##vso[task.uploadsummary]$summaryFile"
+    Write-Output "##vso[task.uploadsummary]$summaryFile"
 
-    Write-Host "`nCoverage summary written: $pct% ($passed/$total tests passed)"
+    Write-Output "`nCoverage summary written: $pct% ($passed/$total tests passed)"
 }
 catch {
     Write-Warning "Coverage summary step encountered an error: $_"

--- a/tests/Common/Environment.tests.ps1
+++ b/tests/Common/Environment.tests.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version Latest
 InModuleScope -ModuleName PSNow {
     Describe 'GetPSNowPsVersion' {
         It 'Returns value of $PSVersionTable.PsVersion.Major' {
-            Mock Get-Variable -ParameterFilter { $Name -eq 'PSVersionTable' -and $ValueOnly } -MockWIth {
+            Mock Get-Variable -ParameterFilter { $Name -eq 'PSVersionTable' -and $ValueOnly } -MockWith {
                 @{ PSVersion = [Version]'5.0.0' }
             }
 
@@ -131,18 +131,18 @@ InModuleScope -ModuleName PSNow {
         }
     }
 
-    if ('Windows' -eq (GetPSNowOs)) {
-        Describe 'Get-PSNowTempRegistry' {
+    Describe 'Get-PSNowTempRegistry' {
+        BeforeEach {
             Mock 'GetPSNowOs' {
                 return 'Windows'
             }
+        }
 
-            It 'return the corret temp registry for Windows' {
+        It 'return the corret temp registry for Windows' -Skip:('Windows' -ne (GetPSNowOs)) {
 
-                $expected = 'Microsoft.PowerShell.Core\Registry::HKEY_CURRENT_USER\Software\PSNow'
-                $tempPath = Get-PSNowTempRegistry
-                $tempPath | Should -Be $expected
-            }
+            $expected = 'Microsoft.PowerShell.Core\Registry::HKEY_CURRENT_USER\Software\PSNow'
+            $tempPath = Get-PSNowTempRegistry
+            $tempPath | Should -Be $expected
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added advisory CI coverage summary step (never blocks merges)
- Added \scripts/Write-CoverageSummary.ps1\: runs Pester with CodeCoverage, writes markdown table with pass rate, coverage %, duration, OS, branch, and top-10 missed commands; always exits 0
- Added 'Coverage summary (advisory)' step in \zure-pipelines.yml\ with \continueOnError: true\
- Fixed \Environment.tests.ps1\ Pester 4 patterns: wrapped bare Mock in BeforeEach, replaced if-wrapped Describe with \-Skip:\ on It block
- Plan: Add non-blocking CI job summary per Walk ex10 requirements
- Files/paths touched: \scripts/Write-CoverageSummary.ps1\, \zure-pipelines.yml\, \	ests/Common/Environment.tests.ps1\

## Evidence
- Tests/logs: Coverage summary written: 68% (309/310 tests passed) locally via \scripts/Write-CoverageSummary.ps1\
- Coverage: 68% (115/169 commands) via Pester CodeCoverage

## Risk & Rollback
- Risk: low
- Rollback: revert this commit; coverage step is \continueOnError: true\ so removing it has zero impact on pipeline stability

## Review Focus
- Verify \continueOnError: true\ is present on coverage step in \zure-pipelines.yml\
- Run: \pwsh scripts/Write-CoverageSummary.ps1\ to see local summary output
- Check Azure DevOps job summary tab for the markdown evidence after pipeline runs

## Track
- Level: Walk
- Exercise: ex10