### PR TITLE
GHCP -- Walk: ex13 Add PSNOW_DISABLE_RETRY feature flag

### DIFF
--- a/Documentation/feature-flags.md
+++ b/Documentation/feature-flags.md
@@ -1,0 +1,107 @@
+# PSNow Feature Flags
+
+PSNow uses environment-variable feature flags to control optional runtime
+behaviour. Each flag follows a standard lifecycle: **off by default → opt-in
+to enable → explicit opt-out to override → remove when the guarded feature
+is permanent**.
+
+---
+
+## Flag reference
+
+| Flag | Default | Effect when ON |
+|------|---------|----------------|
+| `PSNOW_SAFE_MODE` | off | Suppresses the `"Your module was built at: [...]"` path output |
+| `PSNOW_DISABLE_RETRY` | off | Bypasses the `Invoke-Plaster` retry loop; any `ParameterBindingException` propagates immediately |
+
+---
+
+## PSNOW_SAFE_MODE
+
+### Purpose
+Suppresses the informational path message written after a successful module
+creation. Useful in automated pipelines where stdout is parsed and the extra
+line would interfere.
+
+### Default state
+**Off.** The path message is written by default.
+
+### How to enable
+```powershell
+$env:PSNOW_SAFE_MODE = '1'   # also accepts: true, yes, on
+New-PSNowModule -NewModuleName MyMod -BaseManifest Basic
+# no path line printed
+```
+
+### How to disable (restore default)
+```powershell
+Remove-Item Env:PSNOW_SAFE_MODE -ErrorAction SilentlyContinue
+# or
+$env:PSNOW_SAFE_MODE = '0'   # also accepts: false, no, off
+```
+
+### When to remove
+Remove this flag (and the guard in `New-PSNowModule.ps1`) only if the
+verbose path output is removed permanently from the function.
+
+### Code location
+`Public/New-PSNowModule.ps1` — search for `PSNOW_SAFE_MODE`
+
+### Tests
+`tests/Unit/New-PSNowModule.SafeToggle.tests.ps1`
+
+---
+
+## PSNOW_DISABLE_RETRY
+
+### Purpose
+Bypasses the retry loop that strips unknown dynamic Plaster parameters on
+`ParameterBindingException`. When set, `Invoke-Plaster` is called exactly
+once and any exception propagates immediately (fast-fail).
+
+Use this in CI environments where you want immediate failure visibility
+rather than silent parameter removal.
+
+### Default state
+**Off.** The retry loop is active; unknown parameters are stripped and
+`Invoke-Plaster` is retried automatically.
+
+### How to enable
+```powershell
+$env:PSNOW_DISABLE_RETRY = '1'   # also accepts: true, yes, on
+New-PSNowModule -NewModuleName MyMod -BaseManifest Basic
+# ParameterBindingException will now throw immediately
+```
+
+### How to disable (restore default)
+```powershell
+Remove-Item Env:PSNOW_DISABLE_RETRY -ErrorAction SilentlyContinue
+# or
+$env:PSNOW_DISABLE_RETRY = '0'   # also accepts: false, no, off
+```
+
+### When to remove
+Remove this flag once the Plaster template parameter sets are stable and
+the retry logic is no longer needed (i.e., all manifests declare exactly the
+parameters that `New-PSNowModule` passes).
+
+### Code location
+`Public/New-PSNowModule.ps1` — search for `PSNOW_DISABLE_RETRY`
+
+### Tests
+`tests/Unit/New-PSNowModule.RetryToggle.tests.ps1`
+
+---
+
+## Adding a new flag
+
+1. Choose an env-var name with the `PSNOW_` prefix.
+2. Read it in the function using the truthy pattern:
+   ```powershell
+   $flagEnabled = [string]$env:PSNOW_MY_FLAG -match '^(1|true|yes|on)$'
+   ```
+3. Default must be **off** unless the new behaviour is immediately safe for
+   all callers.
+4. Add ON/OFF unit tests in `tests/Unit/`.
+5. Add an entry to this document.
+6. Set a removal criterion — flags should not live forever.

--- a/Public/New-PSNowModule.ps1
+++ b/Public/New-PSNowModule.ps1
@@ -107,34 +107,42 @@ function New-PSNowModule {
             $invokePlasterParams = $PlasterParams.Clone()
             $paramRetryCount = 0
 
-            while ($true) {
-                try {
-                    Invoke-Plaster @invokePlasterParams -Force -Verbose
-                    break
-                }
-                catch [System.Management.Automation.ParameterBindingException] {
-                    # Retry after removing the missing dynamic parameter (if present in our splat).
-                    $missingParameter = [System.Text.RegularExpressions.Regex]::Match(
-                        $_.Exception.Message,
-                        "parameter name '([^']+)'",
-                        [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
-                    ).Groups[1].Value
+            # Feature flag: PSNOW_DISABLE_RETRY bypasses the retry loop for fast-fail behaviour.
+            $disableRetry = [string]$env:PSNOW_DISABLE_RETRY -match '^(1|true|yes|on)$'
 
-                    if ([string]::IsNullOrWhiteSpace($missingParameter) -or -not $invokePlasterParams.ContainsKey($missingParameter)) {
+            if ($disableRetry) {
+                Invoke-Plaster @invokePlasterParams -Force -Verbose
+            }
+            else {
+                while ($true) {
+                    try {
+                        Invoke-Plaster @invokePlasterParams -Force -Verbose
+                        break
+                    }
+                    catch [System.Management.Automation.ParameterBindingException] {
+                        # Retry after removing the missing dynamic parameter (if present in our splat).
+                        $missingParameter = [System.Text.RegularExpressions.Regex]::Match(
+                            $_.Exception.Message,
+                            "parameter name '([^']+)'",
+                            [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+                        ).Groups[1].Value
+
+                        if ([string]::IsNullOrWhiteSpace($missingParameter) -or -not $invokePlasterParams.ContainsKey($missingParameter)) {
+                            throw
+                        }
+
+                        $paramRetryCount++
+                        Write-PSNowStructuredLog -Operation 'invoke-plaster' -Status 'retrying' -Fields ([ordered]@{
+                            retry           = $paramRetryCount
+                            removed_param   = $missingParameter
+                            module_name     = $NewModuleName
+                            manifest        = $BaseManifest
+                        })
+                        $invokePlasterParams.Remove($missingParameter) | Out-Null
+                    }
+                    catch {
                         throw
                     }
-
-                    $paramRetryCount++
-                    Write-PSNowStructuredLog -Operation 'invoke-plaster' -Status 'retrying' -Fields ([ordered]@{
-                        retry           = $paramRetryCount
-                        removed_param   = $missingParameter
-                        module_name     = $NewModuleName
-                        manifest        = $BaseManifest
-                    })
-                    $invokePlasterParams.Remove($missingParameter) | Out-Null
-                }
-                catch {
-                    throw
                 }
             }
 

--- a/tests/Unit/New-PSNowModule.RetryToggle.tests.ps1
+++ b/tests/Unit/New-PSNowModule.RetryToggle.tests.ps1
@@ -1,0 +1,101 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$moduleManifestCandidates = @(
+    (Join-Path $repoRoot 'PSNow.psd1')
+    (Join-Path $repoRoot 'Staging' 'PSNow' 'PSNow.psd1')
+)
+$moduleManifestPath = $moduleManifestCandidates | Where-Object { Test-Path -Path $_ } | Select-Object -First 1
+
+Remove-Module -Name PSNow -Force -ErrorAction SilentlyContinue
+if (-not [string]::IsNullOrWhiteSpace($moduleManifestPath)) {
+    Import-Module -Name $moduleManifestPath -Force -ErrorAction Stop
+}
+
+InModuleScope -ModuleName PSNow {
+    Describe 'New-PSNowModule PSNOW_DISABLE_RETRY toggle' {
+        BeforeEach {
+            Remove-Item Env:PSNOW_DISABLE_RETRY -ErrorAction SilentlyContinue
+            $env:BHPathDivider = [System.IO.Path]::DirectorySeparatorChar
+
+            Mock Get-Variable -ParameterFilter { $Name -eq 'PSVersionTable' -and $ValueOnly } -MockWith {
+                @{ PSVersion = [Version]'7.0.0' }
+            }
+            Mock Set-Location {}
+            Mock Test-Path { $true }
+            Mock Remove-Item {}
+            Mock Get-ChildItem { [pscustomobject]@{ FullName = 'C:\localrepo\PSNow\PlasterTemplate\Basic.xml' } }
+            Mock New-Item {}
+            Mock Add-Content {}
+            Mock Copy-Item {}
+            Mock Write-Verbose {}
+            Mock Write-Output {}
+            Mock Write-PSNowStructuredLog {}
+            Mock Invoke-Plaster {
+                param(
+                    [string]$TemplatePath,
+                    [string]$Destination,
+                    [string]$ModuleName,
+                    [string]$GitHubUserName,
+                    [string]$PowerShellVersion,
+                    [switch]$Force,
+                    [switch]$Verbose
+                )
+                [void]$TemplatePath; [void]$Destination; [void]$ModuleName
+                [void]$GitHubUserName; [void]$PowerShellVersion; [void]$Force; [void]$Verbose
+            }
+        }
+
+        AfterEach {
+            Remove-Item Env:PSNOW_DISABLE_RETRY -ErrorAction SilentlyContinue
+        }
+
+        Context 'flag OFF (default) — retry loop is active' {
+            It 'calls Invoke-Plaster once when no ParameterBindingException is raised' {
+                $null = New-PSNowModule -NewModuleName 'RetryOff' -BaseManifest 'Basic' -ModuleRoot 'c:\modules'
+
+                Should -Invoke Invoke-Plaster -Exactly 1 -Scope It
+            }
+
+            It 'emits retrying log entries when Invoke-Plaster proxy throws for dynamic parameters' {
+                # The Pester mock proxy for Invoke-Plaster lacks Plaster dynamic params
+                # (PowerShellVersion, GitHubUserName). The retry loop catches those
+                # ParameterBindingExceptions and emits a structured log for each.
+                $null = New-PSNowModule -NewModuleName 'RetryOff2' -BaseManifest 'Basic' -ModuleRoot 'c:\modules'
+
+                Should -Invoke Write-PSNowStructuredLog -ParameterFilter { $Status -eq 'retrying' } -Scope It
+            }
+        }
+
+        Context 'flag ON — retry loop is bypassed (fast-fail)' {
+            It 'propagates ParameterBindingException immediately with no retrying log when PSNOW_DISABLE_RETRY=1' {
+                $env:PSNOW_DISABLE_RETRY = '1'
+
+                { New-PSNowModule -NewModuleName 'RetryOn' -BaseManifest 'Basic' -ModuleRoot 'c:\modules' } |
+                    Should -Throw
+
+                Should -Invoke Write-PSNowStructuredLog -ParameterFilter { $Status -eq 'retrying' } -Exactly 0 -Scope It
+            }
+
+            It 'propagates ParameterBindingException immediately when PSNOW_DISABLE_RETRY=true' {
+                $env:PSNOW_DISABLE_RETRY = 'true'
+                Mock Invoke-Plaster {
+                    throw [System.Management.Automation.ParameterBindingException]::new(
+                        "A parameter cannot be found that matches parameter name 'GitHubUserName'."
+                    )
+                }
+
+                { New-PSNowModule -NewModuleName 'RetryFail' -BaseManifest 'Basic' -ModuleRoot 'c:\modules' } |
+                    Should -Throw
+            }
+
+            It 'treats PSNOW_DISABLE_RETRY=0 as OFF and uses the retry loop' {
+                $env:PSNOW_DISABLE_RETRY = '0'
+
+                $null = New-PSNowModule -NewModuleName 'RetryZero' -BaseManifest 'Basic' -ModuleRoot 'c:\modules'
+
+                Should -Invoke Invoke-Plaster -Exactly 1 -Scope It
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added `PSNOW_DISABLE_RETRY` env-var feature flag: when set to `1`/`true`/`yes`/`on`, bypasses the `Invoke-Plaster` retry loop for immediate fast-fail behaviour; default is off (retry loop active)
- Added `tests/Unit/New-PSNowModule.RetryToggle.tests.ps1`: 5 tests validating flag OFF (retry active, retrying log emitted) and flag ON (exception propagates immediately, zero retrying log calls)
- Added `Documentation/feature-flags.md`: lifecycle doc for both `PSNOW_SAFE_MODE` and `PSNOW_DISABLE_RETRY` covering purpose, default state, enable/disable syntax, code location, tests, and removal criteria
- Plan: ex13 — document and validate feature flag ON/OFF states with tests
- Files/paths touched: `Public/New-PSNowModule.ps1`, `tests/Unit/New-PSNowModule.RetryToggle.tests.ps1`, `Documentation/feature-flags.md`

## Evidence
- Tests/logs: 325 passed, 0 failed (`.\Build\build.ps1 -TaskList Stage,Test`)
- Flag OFF validated: retrying log emitted when `Invoke-Plaster` proxy throws for dynamic params
- Flag ON validated: `Should -Throw` and zero retrying log calls confirmed

## Risk & Rollback
- Risk: low — flag is off by default; all existing behaviour unchanged
- Rollback: `git revert 7d88a55`

## Review Focus
- `New-PSNowModule.ps1` ~line 107: verify the `if ($disableRetry)` branch calls `Invoke-Plaster` directly once and the `else` branch contains the full retry loop — both paths must reach the same `completed`/`failed` structured log
- `feature-flags.md`: each flag must have a stated removal criterion so flags do not accumulate permanently
- `RetryToggle.tests.ps1`: the flag-ON test asserts **both** `Should -Throw` AND zero `retrying` log calls — both signals are needed to distinguish fast-fail from retry behaviour
- Confirm `PSNOW_DISABLE_RETRY=0` is treated as OFF (truthy-only pattern: only `1`, `true`, `yes`, `on` are active)

## Verification Steps
```powershell
# Run the new test file
Invoke-Pester -Path tests/Unit/New-PSNowModule.RetryToggle.tests.ps1

# Validate flag ON (fast-fail) — set before importing module:
$env:PSNOW_DISABLE_RETRY = '1'
# New-PSNowModule will throw on first ParameterBindingException

# Validate flag OFF (retry active):
Remove-Item Env:PSNOW_DISABLE_RETRY -ErrorAction SilentlyContinue
# New-PSNowModule strips unknown params and retries automatically
```

## Track
- Level: Walk
- Exercise: ex13
