### PR TITLE
GHCP -- Run: Ex2 Coverage Improvement

### DIFF
--- a/tests/Unit/Environment.Supplemental.tests.ps1
+++ b/tests/Unit/Environment.Supplemental.tests.ps1
@@ -1,0 +1,55 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$moduleManifestCandidates = @(
+    (Join-Path $repoRoot 'Staging\PSNow\PSNow.psd1')
+    (Join-Path $repoRoot 'PSNow.psd1')
+)
+$moduleManifestPath = $moduleManifestCandidates | Where-Object { Test-Path -Path $_ } | Select-Object -First 1
+
+Remove-Module -Name PSNow -Force -ErrorAction SilentlyContinue
+if (-not [string]::IsNullOrWhiteSpace($moduleManifestPath)) {
+    Import-Module -Name $moduleManifestPath -Force -ErrorAction Stop
+}
+
+InModuleScope -ModuleName PSNow {
+
+    Describe 'Get-PSNowTempDirectory supplemental' {
+
+        Context 'Linux path (non-Windows, non-macOS)' {
+            It 'returns GetTempPath trimmed of directory separator' {
+                Mock GetPSNowOs { 'Linux' }
+
+                $result = Get-PSNowTempDirectory
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -Not -Match ([regex]::Escape([System.IO.Path]::DirectorySeparatorChar) + '$')
+            }
+        }
+    }
+
+    Describe 'Get-PSNowTempRegistry supplemental' {
+
+        Context 'when the registry key does not yet exist' {
+            It 'creates the registry key' {
+                Mock Test-Path { $false }
+                Mock New-Item {}
+
+                Get-PSNowTempRegistry | Out-Null
+
+                Should -Invoke New-Item -Exactly 1 -Scope It
+            }
+        }
+
+        Context 'when registry key creation fails' {
+            It 'throws a wrapped exception with descriptive message' {
+                Mock Test-Path { $false }
+                Mock New-Item { throw [Exception]::new('access denied') }
+
+                {
+                    Get-PSNowTempRegistry
+                } | Should -Throw 'Was not able to create a Pester Registry key for TestRegistry'
+            }
+        }
+    }
+}

--- a/tests/Unit/Find-PSNowModule.Behavior.tests.ps1
+++ b/tests/Unit/Find-PSNowModule.Behavior.tests.ps1
@@ -1,0 +1,103 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$moduleManifestCandidates = @(
+    (Join-Path $repoRoot 'Staging\PSNow\PSNow.psd1')
+    (Join-Path $repoRoot 'PSNow.psd1')
+)
+$moduleManifestPath = $moduleManifestCandidates | Where-Object { Test-Path -Path $_ } | Select-Object -First 1
+
+Remove-Module -Name PSNow -Force -ErrorAction SilentlyContinue
+if (-not [string]::IsNullOrWhiteSpace($moduleManifestPath)) {
+    Import-Module -Name $moduleManifestPath -Force -ErrorAction Stop
+}
+
+InModuleScope -ModuleName PSNow {
+    Describe 'Find-PSNowModule behavior' {
+        BeforeEach {
+            Mock Write-Output {}
+            Mock Test-Path { $false }
+            Mock Get-Content { @() }
+        }
+
+        Context 'when currentmodules.txt does not exist' {
+            It 'outputs a friendly no-modules message' {
+                Mock Test-Path { $false }
+
+                Find-PSNowModule
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq 'No modules have been created with PSNow yet.'
+                } -Exactly 1 -Scope It
+            }
+
+            It 'does not read the tracker file when it is missing' {
+                Mock Test-Path { $false }
+
+                Find-PSNowModule
+
+                Should -Invoke Get-Content -Exactly 0 -Scope It
+            }
+        }
+
+        Context 'when currentmodules.txt exists with entries' {
+            BeforeEach {
+                Mock Test-Path { $true }
+                Mock Get-Content { @('C:\modules\ModuleA', 'C:\modules\ModuleB') }
+            }
+
+            It 'reads the tracker file' {
+                Find-PSNowModule
+
+                Should -Invoke Get-Content -Exactly 1 -Scope It
+            }
+
+            It 'outputs the section header' {
+                Find-PSNowModule
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq "Here's your list of PSNow Modules"
+                } -Exactly 1 -Scope It
+            }
+
+            It 'outputs the separator line' {
+                Find-PSNowModule
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq '---------------------------------'
+                } -Exactly 1 -Scope It
+            }
+
+            It 'outputs each module path' {
+                Find-PSNowModule
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq 'C:\modules\ModuleA'
+                } -Exactly 1 -Scope It
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq 'C:\modules\ModuleB'
+                } -Exactly 1 -Scope It
+            }
+        }
+
+        Context 'when currentmodules.txt exists but is empty' {
+            BeforeEach {
+                Mock Test-Path { $true }
+                Mock Get-Content { @() }
+            }
+
+            It 'outputs the header without any module paths' {
+                Find-PSNowModule
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq "Here's your list of PSNow Modules"
+                } -Exactly 1 -Scope It
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -match '^C:\\'
+                } -Exactly 0 -Scope It
+            }
+        }
+    }
+}

--- a/tests/Unit/New-PSNowModule.DefaultRoot.tests.ps1
+++ b/tests/Unit/New-PSNowModule.DefaultRoot.tests.ps1
@@ -1,0 +1,78 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$moduleManifestCandidates = @(
+    (Join-Path $repoRoot 'Staging\PSNow\PSNow.psd1')
+    (Join-Path $repoRoot 'PSNow.psd1')
+)
+$moduleManifestPath = $moduleManifestCandidates | Where-Object { Test-Path -Path $_ } | Select-Object -First 1
+
+Remove-Module -Name PSNow -Force -ErrorAction SilentlyContinue
+if (-not [string]::IsNullOrWhiteSpace($moduleManifestPath)) {
+    Import-Module -Name $moduleManifestPath -Force -ErrorAction Stop
+}
+
+InModuleScope -ModuleName PSNow {
+    Describe 'New-PSNowModule default ModuleRoot' {
+        BeforeEach {
+            $env:BHPathDivider = [System.IO.Path]::DirectorySeparatorChar
+
+            Mock Get-Variable -ParameterFilter { $Name -eq 'PSVersionTable' -and $ValueOnly } -MockWith {
+                @{ PSVersion = [Version]'5.1.0' }
+            }
+
+            Mock Set-Location {}
+            Mock Remove-Item {}
+            Mock Get-ChildItem { [pscustomobject]@{ FullName = 'C:\localrepo\PSNow\PlasterTemplate\Basic.xml' } }
+            Mock Copy-Item {}
+            Mock Write-Output {}
+            Mock Write-Verbose {}
+            Mock Add-Content {}
+            Mock Invoke-Plaster {
+                param(
+                    [string]$TemplatePath,  [string]$Destination,  [string]$ModuleName,
+                    [string]$GitHubUserName, [string]$PowerShellVersion,
+                    [switch]$Force,          [switch]$Verbose
+                )
+                [void]$TemplatePath; [void]$Destination; [void]$ModuleName
+                [void]$GitHubUserName; [void]$PowerShellVersion; [void]$Force; [void]$Verbose
+            }
+        }
+
+        Context 'when ModuleRoot is not supplied' {
+            It 'uses the OS-appropriate default path on Windows' {
+                Mock GetPSNowOs { 'Windows' }
+                # Test-Path: return true for ModuleRoot existence check so New-Item is not called
+                Mock Test-Path { $true }
+
+                # No -ModuleRoot argument; function must assign the default
+                { New-PSNowModule -NewModuleName 'DefaultRootTest' -BaseManifest 'Basic' } |
+                    Should -Not -Throw
+            }
+
+            It 'uses ~/modules default path on non-Windows' {
+                Mock GetPSNowOs { 'Linux' }
+                Mock Test-Path { $true }
+
+                { New-PSNowModule -NewModuleName 'DefaultRootLinux' -BaseManifest 'Basic' } |
+                    Should -Not -Throw
+            }
+        }
+
+        Context 'when ModuleRoot directory does not exist' {
+            It 'creates the directory' {
+                # First Test-Path (for ModuleRoot existence) returns false; all others true
+                $callCount = 0
+                Mock Test-Path {
+                    $callCount++
+                    $callCount -gt 1
+                }
+                Mock New-Item {}
+
+                New-PSNowModule -NewModuleName 'MissingDir' -BaseManifest 'Basic' -ModuleRoot 'C:\nonexistent\path'
+
+                Should -Invoke New-Item -Scope It
+            }
+        }
+    }
+}

--- a/tests/Unit/Write-PSNowScriptNoWhitespace.tests.ps1
+++ b/tests/Unit/Write-PSNowScriptNoWhitespace.tests.ps1
@@ -1,0 +1,58 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$moduleManifestCandidates = @(
+    (Join-Path $repoRoot 'Staging\PSNow\PSNow.psd1')
+    (Join-Path $repoRoot 'PSNow.psd1')
+)
+$moduleManifestPath = $moduleManifestCandidates | Where-Object { Test-Path -Path $_ } | Select-Object -First 1
+
+Remove-Module -Name PSNow -Force -ErrorAction SilentlyContinue
+if (-not [string]::IsNullOrWhiteSpace($moduleManifestPath)) {
+    Import-Module -Name $moduleManifestPath -Force -ErrorAction Stop
+}
+
+InModuleScope -ModuleName PSNow {
+    Describe 'Write-PSNowScriptNoWhitespace' {
+        BeforeEach {
+            Mock Resolve-Path { 'C:\fake\module' }
+            Mock Split-Path { 'C:\fake\module' }
+            Mock Set-Location {}
+            Mock Get-ChildItem { @() }
+            Mock Get-Content { @() }
+            Mock Set-Content {}
+        }
+
+        It 'sets the working location to the project root' {
+            Write-PSNowScriptNoWhitespace
+
+            Should -Invoke Set-Location -Exactly 1 -Scope It
+        }
+
+        It 'enumerates scripts under the module root' {
+            Write-PSNowScriptNoWhitespace
+
+            Should -Invoke Get-ChildItem -Exactly 1 -Scope It
+        }
+
+        Context 'when script files are found' {
+            BeforeEach {
+                $fakeFile = [pscustomobject]@{ FullName = 'C:\fake\module\Public\Test.ps1' }
+                Mock Get-ChildItem { $fakeFile }
+                Mock Get-Content { @('line one   ', 'line two  ') }
+            }
+
+            It 'reads each script file' {
+                Write-PSNowScriptNoWhitespace
+
+                Should -Invoke Get-Content -Exactly 1 -Scope It
+            }
+
+            It 'writes trimmed content back to each script file' {
+                Write-PSNowScriptNoWhitespace
+
+                Should -Invoke Set-Content -Scope It
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Title: GHCP -- Run: Ex2 Coverage Improvement

## Summary
- Find-PSNowModule.ps1 was 0% covered (12 missed lines); added InModuleScope tests covering missing-file early-return, header output, and per-module listing
- Write-PSNowScriptNoWhitespace.ps1 was 0% covered (7 missed lines); added mocked tests for Set-Location, Get-ChildItem enumeration, and Get-Content/Set-Content loop
- Get-PSNowEnvironmentVariables.ps1 had 3 missed lines; added Linux TrimEnd path, New-Item registry creation path, and catch/throw in Get-PSNowTempRegistry
- New-PSNowModule.ps1 had 2 missed lines; added default ModuleRoot assignment (Windows + Linux) and New-Item call when target directory is absent
- Files/paths touched: tests/Unit/Find-PSNowModule.Behavior.tests.ps1, tests/Unit/Write-PSNowScriptNoWhitespace.tests.ps1, tests/Unit/Environment.Supplemental.tests.ps1, tests/Unit/New-PSNowModule.DefaultRoot.tests.ps1

## Evidence
- Before: 75.16% (161 commands analyzed)
- After: 97.52% (161 commands analyzed)
- Improvement: +22.36% (target was +2%)
- Tests Passed: 295, Failed: 0, Skipped: 4
- Run command: pwsh -NoProfile -NonInteractive -File ./scripts/run-coverage.ps1
- Output: "Covered 97.52% / 75%. 161 analyzed Commands in 7 Files."
- Delegation checklist completed: yes

## Risk & Rollback
- Risk: low (new test files only, no production code changed)
- Rollback: revert this commit
- Rollback commands: git revert 7885006

## Track
- Level: Run
- Exercise: Ex2