### PR TITLE
GHCP -- Run: Ex4 Documentation Refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,34 +72,35 @@ git checkout -b walk-ex5
 
 ## PR Expectations
 
-Every PR must include the following sections. Use the template below as your PR body:
+Every PR must follow the template at `.github/PULL_REQUEST_TEMPLATE.md`.  
+The required sections are:
 
 ```
+## Title: GHCP -- Run: <ex#> <name>
+
 ## Summary
 - What changed and why
-- Plan: <inline summary or link>
-- Files/paths touched
+- Patch plan reference (if applicable)
+- Files/paths/folders touched
 
 ## Evidence
+- Before/after metrics or screenshots: <data>
 - Tests/logs/metrics: <commands + output summary>
-- Coverage: <percentage or contract evidence>
+- Delegation checklist completed: yes/no
 
 ## Risk & Rollback
-- Risk: low/medium/high
+- Risk: low/medium
 - Rollback: revert <commit SHA> or toggle <flag>
-
-## Review Focus
-- Key areas for reviewer attention
-- Verification steps the reviewer can run
+- Rollback commands: <exact commands if applicable>
 
 ## Track
-- Level: Walk
-- Exercise: ex<N>
+- Level: Run
+- Exercise: <ex#>
 ```
 
 **Evidence is mandatory.** Paste the test result line from `validate.ps1`:
 ```
-Tests Passed: 266, Failed: 0, Skipped: 4
+Tests Passed: 307, Failed: 0, Skipped: 4
 ```
 
 ---

--- a/Documentation/Find-PSNowModule.md
+++ b/Documentation/Find-PSNowModule.md
@@ -39,6 +39,36 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
-General Notes
+
+### Key File Paths
+
+| Path | Purpose |
+|---|---|
+| `Public/Find-PSNowModule.ps1` | This function |
+| `currentmodules.txt` | Append-only registry at the **module install root** (the directory containing `PSNow.psd1`). Each line is an absolute path to a module created by `New-PSNowModule`. |
+
+### Behaviour When No Modules Exist
+
+If `currentmodules.txt` does not exist at the expected path, `Find-PSNowModule`  
+writes `"No modules have been created with PSNow yet."` and returns without error.
+
+### Extension Guidance
+
+`Find-PSNowModule` reads the same `currentmodules.txt` file that `New-PSNowModule`  
+appends to. To extend the registry format:
+
+1. Update `Public/New-PSNowModule.ps1` to write additional columns (e.g. CSV).
+2. Update `Find-PSNowModule` to parse the new format.
+3. Keep backward compatibility — existing single-path lines should still display.
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| `currentmodules.txt` paths become stale if a module is moved or deleted | `Find-PSNowModule` lists paths as-is; it does not validate that they still exist. Use `Test-Path` on each returned path to check. |
+| Multiple PSNow installs writing to different `currentmodules.txt` files | The path is resolved relative to `$PSScriptRoot` of the installed module. Side-by-side installs each have their own registry file. |
 
 ## RELATED LINKS
+
+- [`New-PSNowModule`](./New-PSNowModule.md)
+- [`Public/Find-PSNowModule.ps1`](../Public/Find-PSNowModule.ps1)

--- a/Documentation/New-PSNowModule.md
+++ b/Documentation/New-PSNowModule.md
@@ -55,15 +55,32 @@ New-PSNowModule -NewModuleName "MyFabModule" -BaseManifest Advanced -ModuleRoot 
 This choice creates a fully fleshed out PowerShell module with full support for Pester, Git, PlatyPS and more.
 See the Advanced.xml file located in /PlasterTemplate
 
-### Resilience Improvements
+### Resilience — Plaster Parameter Stripping
 
-The `New-PSNowModule` function includes a retry mechanism for critical operations, such as file creation or Plaster invocation. This mechanism retries up to 3 times with exponential backoff in case of transient errors.
+`New-PSNowModule` delegates Plaster invocation to the private helper  
+`Private/Invoke-PSNowPlasterSafely.ps1`.
+
+When `Invoke-Plaster` raises a `ParameterBindingException` for an unrecognised  
+parameter (e.g. a template-specific dynamic parameter that the selected manifest  
+does not declare), the helper:
+
+1. Extracts the offending parameter name from the exception message.  
+2. Removes it from the splat.  
+3. Retries `Invoke-Plaster` with the reduced parameter set.  
+4. Repeats until the call succeeds or until no further named parameter can be  
+   stripped — at which point the exception is rethrown.
+
+There is **no fixed retry cap** and **no backoff delay**.  
+This mechanism handles only `ParameterBindingException`; all other exception  
+types are rethrown immediately.
+
+> **Note:** File-system operations (e.g. creating `$ModuleRoot`) do **not** have  
+> a retry wrapper. Only Plaster invocation is protected.
 
 #### Example
 ```powershell
 New-PSNowModule -NewModuleName "MyModule" -BaseManifest "Advanced"
 ```
-If a transient error occurs during module creation, the function will retry the operation before failing with an error message.
 
 ## PARAMETERS
 
@@ -121,6 +138,69 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
-General Notes
+
+### Structured Logging
+
+Every call to `Invoke-Plaster` is bracketed by two structured log entries written  
+by `Private/Write-PSNowStructuredLog.ps1`:
+
+| Event | Fields logged |
+|---|---|
+| `invoke-plaster / started` | `module_name`, `manifest`, `destination`, `elapsed_ms = 0` |
+| `invoke-plaster / completed` | same fields plus actual `elapsed_ms` |
+| `invoke-plaster / failed` | same fields plus `error` (exception message) |
+
+Log output goes to the PowerShell information stream (visible with `-Verbose`).
+
+### Key File Paths
+
+| Path | Purpose |
+|---|---|
+| `Public/New-PSNowModule.ps1` | This function |
+| `Private/Invoke-PSNowPlasterSafely.ps1` | Plaster invocation + parameter-stripping retry |
+| `Private/Write-PSNowStructuredLog.ps1` | Structured log emitter |
+| `Private/Remove-OldPSNowManifest.ps1` | Cleans up stale `PlasterManifest.xml` before each run |
+| `PlasterTemplate/Basic.xml` | Minimal module scaffold |
+| `PlasterTemplate/Extended.xml` | Module with tests and build helpers |
+| `PlasterTemplate/Advanced.xml` | Full module with Pester, PlatyPS, Git support |
+| `currentmodules.txt` | Append-only registry of created module paths (repo root) |
+
+### Environment Variables
+
+| Variable | Effect |
+|---|---|
+| `PSNOW_SAFE_MODE` | Set to `1`, `true`, `yes`, or `on` to suppress the output path message |
+| `BHGitHubUser` | Passed to Plaster as `GitHubUserName`; set in your PowerShell profile |
+
+### Extension Guidance
+
+**Adding a new Plaster manifest:**
+
+1. Create `PlasterTemplate/<Name>.xml` following the Plaster schema.
+2. Add `"<Name>"` to the `[ValidateSet]` on `-BaseManifest` in  
+   `Public/New-PSNowModule.ps1`.
+3. Add a test case in `tests/Integration/` that calls  
+   `New-PSNowModule -BaseManifest <Name>` against a temp directory.
+4. Run `./Build/Build.ps1 -TaskList stage,analyze,test` to validate.
+
+**Adding a new parameter to pass through to Plaster:**
+
+Add the key/value pair to the `$PlasterParams` hashtable in `New-PSNowModule.ps1`.  
+If the selected manifest does not declare the parameter, `Invoke-PSNowPlasterSafely`  
+will silently strip it on the first `ParameterBindingException` and retry — no  
+additional guard code is needed.
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| `PSNOW_SAFE_MODE` set unexpectedly in CI | The path output is suppressed but the module is still created normally. CI should not depend on the output message. |
+| `BHGitHubUser` not set | `GitHubUserName` will be `$null`; Plaster strips it via the retry mechanism. The generated module will have no GitHub user pre-filled. |
+| `currentmodules.txt` growing without bound | `Add-Content` appends one line per call. Prune manually or via `Find-PSNowModule` review. |
+| Wrong `$ModuleRoot` path on Linux | Paths default to `~/modules` on non-Windows. Ensure the `~` expansion resolves correctly under the CI agent user. |
 
 ## RELATED LINKS
+
+- [`Find-PSNowModule`](./Find-PSNowModule.md)
+- [`Private/Invoke-PSNowPlasterSafely.ps1`](../Private/Invoke-PSNowPlasterSafely.ps1)
+- [`PlasterTemplate/`](../PlasterTemplate/)


### PR DESCRIPTION
## Title: GHCP -- Run: Ex4 Documentation Refresh

## Summary
- Audited the Documentation/ subsystem and found two stale/incomplete reference docs and a CONTRIBUTING.md PR template that no longer matched the live template file.
- Refreshed all three. No code changes were needed.
- Files touched: Documentation/New-PSNowModule.md, Documentation/Find-PSNowModule.md, CONTRIBUTING.md

**Gaps fixed:**

New-PSNowModule.md
- Replaced factually wrong 'retries up to 3 times with exponential backoff' claim with accurate description of Invoke-PSNowPlasterSafely (strips one unknown parameter per iteration, no retry cap, no backoff, rethrows for all other exception types)
- Added structured-logging table documenting the invoke-plaster started/completed/failed events
- Added key file paths table referencing real paths (Public/, Private/, PlasterTemplate/)
- Added environment variables table (PSNOW_SAFE_MODE, BHGitHubUser)
- Added extension guidance (how to add a new manifest or pass-through parameter)
- Added risk table (4 named risks with mitigations)

Find-PSNowModule.md
- Added real path for currentmodules.txt with explanation of where it lives
- Documented no-file-present behaviour ('No modules have been created yet')
- Added extension guidance and risk table (stale paths, side-by-side installs)

CONTRIBUTING.md
- Updated PR template section to match .github/PULL_REQUEST_TEMPLATE.md exactly

## Evidence
- Before/after metrics: documentation only, no metrics
- Tests/logs/metrics: pwsh -NoProfile -NonInteractive -File ./Build/build.ps1 -TaskList test -- Tests Passed: 307, Failed: 0, Skipped: 4
- Delegation checklist completed: yes

## Risk & Rollback
- Risk: low (documentation only, no code changes)
- Rollback: git revert c9a389d752a9050a6f051637195a62ced0ea2de4 --no-edit
- Rollback commands: git revert c9a389d752a9050a6f051637195a62ced0ea2de4 --no-edit && git push

## Track
- Level: Run
- Exercise: Ex4