### PR TITLE
GHCP -- Run: Ex6 Performance Optimization

### DIFF
--- a/Private/Remove-OldPSNowManifest.ps1
+++ b/Private/Remove-OldPSNowManifest.ps1
@@ -20,7 +20,9 @@ function Remove-OldPSNowManifest {
         Remove-Item -Path $lowerManifest
     }
 
-    $plasterdoc = Get-ChildItem (Join-Path -Path $TemplateRoot -ChildPath 'PlasterTemplate') -Filter "$BaseManifest.xml" |
-        ForEach-Object { $_.FullName }
+    # Build the source path directly — the filename is always "$BaseManifest.xml" and
+    # the directory is always PlasterTemplate/. This avoids a Get-ChildItem directory
+    # scan on every New-PSNowModule call.
+    $plasterdoc = Join-Path -Path $TemplateRoot -ChildPath 'PlasterTemplate' -AdditionalChildPath "$BaseManifest.xml"
     Copy-Item -Path $plasterdoc -Destination $lowerManifest
 }

--- a/ai-track-docs/perf-baseline.md
+++ b/ai-track-docs/perf-baseline.md
@@ -1,56 +1,23 @@
-# Performance Baseline
+# Performance Baseline — Exercise 6
+# Measured: 2026-05-27, Windows, PSNow repo
 
-Date: 2026-05-18
-Branch: ex6
-Function measured: `Find-PSNowModule`
+## Remove-OldPSNowManifest — template path lookup
+Method                  | 1000 calls (ms) | Per call (ms)
+------------------------|-----------------|---------------
+BEFORE: Get-ChildItem   |     994 ms      |  0.994 ms
+AFTER: Join-Path direct |      28 ms      |  0.028 ms
+Improvement             |                 | 97.2%
 
-## Benchmark Command
+## Write-PSNowStructuredLog — List vs array+=
+FINDING (not implemented): List[string] approach showed 54% SLOWER for 4-6 items
+because List::new() constructor overhead dominates at small collection sizes.
+Reverted to original array+= approach. No change made.
 
-```powershell
-Import-Module ./PSNow.psd1 -Force
-$runs = 12
-$iterations = 2000
-$samples = for ($r=1; $r -le $runs; $r++) {
-    $sw = [System.Diagnostics.Stopwatch]::StartNew()
-    for ($i=0; $i -lt $iterations; $i++) {
-        $null = Find-PSNowModule | Out-Null
-    }
-    $sw.Stop()
-    [pscustomobject]@{
-        Run       = $r
-        TotalMs   = [math]::Round($sw.Elapsed.TotalMilliseconds, 3)
-        PerCallUs = [math]::Round(($sw.Elapsed.TotalMilliseconds * 1000.0) / $iterations, 3)
-    }
-}
-$stats = $samples | Measure-Object -Property PerCallUs -Average -Minimum -Maximum -StandardDeviation
-```
+## GetPSNowOs — module-scoped cache
+FINDING (not implemented): Cache correctly eliminates repeated OS detection calls
+but breaks Pester test isolation — cache populated in test N poisons test N+1 when
+tests mock GetPSNowPsVersion. Would require BeforeEach {  =  }
+in all affected test files. Reverted.
 
-## Baseline Results
-
-- Runs: 12
-- Iterations per run: 2000
-- Average: 483.552 us per call
-- Min: 465.942 us per call
-- Max: 501.405 us per call
-- StdDev: 12.399 us
-
-## Per-Run Samples (us/call)
-
-- Run 1: 492.770
-- Run 2: 465.940
-- Run 3: 467.540
-- Run 4: 467.090
-- Run 5: 489.040
-- Run 6: 472.950
-- Run 7: 482.340
-- Run 8: 494.580
-- Run 9: 485.470
-- Run 10: 501.400
-- Run 11: 486.960
-- Run 12: 496.540
-
-## Variance Notes
-
-- Spread was modest in this run (`min` to `max` span about 35.463 us).
-- Standard deviation was 12.399 us, indicating relatively tight clustering around the mean.
-- No optimization changes were made as part of this exercise; this file is measurement-only.
+## Module import time (unchanged)
+5 runs: 126, 90, 84, 85, 91 ms | Average: 95.2 ms


### PR DESCRIPTION
## Title: GHCP -- Run: Ex6 Performance Optimization

## Summary
- Profiled Private/ to identify optimization opportunities. Three candidates evaluated; one implemented.
- **Implemented:** Private/Remove-OldPSNowManifest.ps1 -- replaced Get-ChildItem directory scan with direct Join-Path path construction. The template filename is always '\.xml' in a known subdirectory -- no scan required.
- **Reverted (Write-PSNowStructuredLog):** List[string] approach benchmarked 54% SLOWER than array+= for 4-6 items. Constructor overhead dominates at small collection sizes.
- **Reverted (GetPSNowOs cache):** Module-scoped caching broke Pester test isolation -- cache populated in test N bled into test N+1 when mocks were in use. Safe to implement only after adding BeforeEach cache-clear to affected test files.
- Files touched: Private/Remove-OldPSNowManifest.ps1, ai-track-docs/perf-baseline.md

## Evidence
- Before: Get-ChildItem scan -- 0.994 ms/call (1000 calls: 994 ms total)
- After:  Join-Path direct  -- 0.028 ms/call (1000 calls: 28 ms total)
- Improvement: 97.2% reduction in template path lookup time per New-PSNowModule call
- Tests/logs/metrics: Tests Passed: 316, Failed: 0, Skipped: 4
- Delegation checklist completed: yes

## Risk & Rollback
- Risk: low -- the optimized path is deterministic and produces the same string as the Get-ChildItem result. Behavior is identical.
- Rollback: git revert e2424a7255018e9fb190a6594b971663b8971e50 --no-edit
- Rollback commands: git revert e2424a7255018e9fb190a6594b971663b8971e50 --no-edit && git push

## Track
- Level: Run
- Exercise: Ex6