### PR TITLE
GHCP -- Run: Ex11 Code Review Process

### DIFF
--- a/Public/Find-PSNowModule.ps1
+++ b/Public/Find-PSNowModule.ps1
@@ -3,12 +3,25 @@
 Finds your PSNow created modules
 
 .DESCRIPTION
-When you use PSNow to create a module, it adds the name and location to a file called Currentmodules.txt. That list is returned to you here.
+When you use PSNow to create a module, it adds the name and location to a file called
+Currentmodules.txt. That list is returned to you here.
+
+Blank lines in the tracker file are silently filtered out. Use -Validate to flag
+paths that no longer exist on disk.
+
+.PARAMETER Validate
+When specified, each listed path is tested for existence. Paths that no longer
+exist on disk are marked with [STALE] in the output.
 
 .EXAMPLE
 Find-PSNowModule
 
-There are no parameters to add here, you're just getting a list of modules returned to you.
+Returns the list of all modules created with PSNow.
+
+.EXAMPLE
+Find-PSNowModule -Validate
+
+Returns the list with [STALE] appended to any path that no longer exists on disk.
 
 .NOTES
 General Notes
@@ -16,7 +29,10 @@ General Notes
 #>
 function Find-PSNowModule {
     [CmdletBinding()]
+    [OutputType([string[]])]
     param (
+        [Parameter()]
+        [switch]$Validate
     )
 
     begin {
@@ -39,7 +55,10 @@ function Find-PSNowModule {
             return
         }
 
-        $modules = Get-Content -Path $thefile
+        # Blank lines accumulate when entries are appended across runs.
+        # Filter them on read to keep output clean without modifying the file.
+        $modules = Get-Content -Path $thefile | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
         Write-PSNowStructuredLog -Operation 'find-modules' -Status 'completed' -Fields ([ordered]@{
             count = $modules.Count
             path  = $thefile
@@ -48,8 +67,13 @@ function Find-PSNowModule {
         Write-Output "`n"
         Write-Output "Here's your list of PSNow Modules"
         Write-Output "---------------------------------"
-        foreach($module in $modules){
-            Write-Output $module
+        foreach ($module in $modules) {
+            if ($Validate -and -not (Test-Path -Path $module -PathType Container)) {
+                Write-Output "$module [STALE]"
+            }
+            else {
+                Write-Output $module
+            }
         }
         Write-Output "`n"
 

--- a/tests/Unit/Find-PSNowModule.Validate.tests.ps1
+++ b/tests/Unit/Find-PSNowModule.Validate.tests.ps1
@@ -1,0 +1,124 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$moduleManifestCandidates = @(
+    (Join-Path $repoRoot 'Staging\PSNow\PSNow.psd1')
+    (Join-Path $repoRoot 'PSNow.psd1')
+)
+$moduleManifestPath = $moduleManifestCandidates | Where-Object { Test-Path -Path $_ } | Select-Object -First 1
+
+Remove-Module -Name PSNow -Force -ErrorAction SilentlyContinue
+if (-not [string]::IsNullOrWhiteSpace($moduleManifestPath)) {
+    Import-Module -Name $moduleManifestPath -Force -ErrorAction Stop
+}
+
+InModuleScope -ModuleName PSNow {
+    Describe 'Find-PSNowModule -Validate and empty-line filtering' {
+        BeforeEach {
+            Mock Write-Output {}
+        }
+
+        Context '-Validate: path exists' {
+            It 'outputs the path without [STALE] when the directory is present' {
+                Mock Test-Path { $true }
+                Mock Get-Content { @('C:\modules\ModuleA') }
+
+                Find-PSNowModule -Validate
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq 'C:\modules\ModuleA'
+                } -Exactly 1 -Scope It
+            }
+
+            It 'does not append [STALE] when the directory exists' {
+                Mock Test-Path { $true }
+                Mock Get-Content { @('C:\modules\ModuleA') }
+
+                Find-PSNowModule -Validate
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -match '\[STALE\]'
+                } -Exactly 0 -Scope It
+            }
+        }
+
+        Context '-Validate: path does not exist' {
+            It 'appends [STALE] to a path that no longer exists on disk' {
+                Mock Test-Path -ParameterFilter { $Path -eq $thefile } { $true }
+                Mock Test-Path { $false }
+                Mock Get-Content { @('C:\modules\GoneModule') }
+
+                Find-PSNowModule -Validate
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq 'C:\modules\GoneModule [STALE]'
+                } -Exactly 1 -Scope It
+            }
+
+            It 'marks only the missing paths while leaving present paths clean' {
+                $script:testPathCallCount = 0
+                Mock Test-Path {
+                    param([string]$Path, [string]$PathType)
+                    if ($PathType -eq 'Container') {
+                        $Path -eq 'C:\modules\GoodModule'
+                    }
+                    else {
+                        $true  # tracker file exists
+                    }
+                }
+                Mock Get-Content { @('C:\modules\GoodModule', 'C:\modules\GoneModule') }
+
+                Find-PSNowModule -Validate
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq 'C:\modules\GoodModule'
+                } -Exactly 1 -Scope It
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq 'C:\modules\GoneModule [STALE]'
+                } -Exactly 1 -Scope It
+            }
+        }
+
+        Context 'empty-line filtering' {
+            It 'does not output blank lines from the tracker file' {
+                Mock Test-Path { $true }
+                Mock Get-Content { @('C:\modules\ModuleA', '', '   ', 'C:\modules\ModuleB') }
+
+                Find-PSNowModule
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    [string]::IsNullOrWhiteSpace($InputObject)
+                } -Exactly 2 -Scope It  # only the two intentional blank Write-Output "`n" calls
+            }
+
+            It 'outputs exactly the non-blank paths' {
+                Mock Test-Path { $true }
+                Mock Get-Content { @('C:\modules\ModuleA', '', 'C:\modules\ModuleB') }
+
+                Find-PSNowModule
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq 'C:\modules\ModuleA' -or $InputObject -eq 'C:\modules\ModuleB'
+                } -Exactly 2 -Scope It
+            }
+        }
+
+        Context 'no -Validate: existing behaviour unchanged' {
+            It 'outputs all paths as-is when -Validate is not used' {
+                Mock Test-Path { $true }
+                Mock Get-Content { @('C:\modules\ModuleA') }
+
+                Find-PSNowModule  # no -Validate
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -eq 'C:\modules\ModuleA'
+                } -Exactly 1 -Scope It
+
+                Should -Invoke Write-Output -ParameterFilter {
+                    $InputObject -match '\[STALE\]'
+                } -Exactly 0 -Scope It
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Added a `-Validate` switch and empty-line filtering to `Find-PSNowModule`. When `-Validate` is specified, each tracked module path is tested for existence on disk; paths that no longer exist are marked with `[STALE]` in the output. Blank lines that accumulate in the tracker file over time are now silently filtered on read. Ex9 structured logging is preserved throughout. Seven new Pester tests cover all new code paths.

## What Changed

- **`Public/Find-PSNowModule.ps1`** — added `-Validate` switch, `Where-Object` empty-line filter, `[OutputType([string[]])]`, updated comment-based help with parameter docs and a second example. Ex9 `Write-PSNowStructuredLog` calls retained.
- **`tests/Unit/Find-PSNowModule.Validate.tests.ps1`** — 7 new tests (367 total): path exists, path missing, mixed list, empty-line filtering, no-Validate backward compat.

## Review Checklist

| Area | Risk | Finding | Resolution |
|---|---|---|---|
| Correctness | Medium | `-like '*[STALE]*'` treated `[STALE]` as a character class, matching any string containing S/T/A/L/E | Fixed to `-match '\[STALE\]'` |
| Test coverage | Low | All new branches exercised: exists, missing, mixed, empty lines, no-Validate | Done |
| Security | Low | `-Validate` is read-only; only calls `Test-Path`, no writes or deletes | No action needed |
| Performance | Low | `Where-Object` filter is O(n) on file lines; negligible for typical module lists | Accepted |
| Documentation | Low | Synopsis, Description, Parameter block, two Examples all updated | Done |

## Evidence

- 367 tests pass, 0 PSSA errors (Windows local)
- CI triggered on push to `run-ex11`

## Rollback

Revert `Public/Find-PSNowModule.ps1` to the prior commit. The new test file can remain — it will simply not exercise the `-Validate` parameter against the reverted code and those tests will fail, signalling the revert is in effect.