### PR TITLE
GHCP -- Run: Ex13 Feature Flag - PSNOW_STRICT_LOG_SANITIZATION

### DIFF
--- a/Documentation/feature-flags.md
+++ b/Documentation/feature-flags.md
@@ -1,0 +1,86 @@
+# PSNow Feature Flags
+
+PSNow uses environment variables to control optional or evolving behaviour without
+requiring code changes. Flags default to **OFF** (opt-in) — new behaviour must be
+explicitly enabled, ensuring existing pipelines are unaffected on upgrade.
+
+## Flag Helper
+
+`Get-PSNowFeatureFlag -Name '<FlagName>'`
+
+Reads `$env:PSNOW_<FLAG_NAME_UPPERCASE>` and returns `$true` (enabled) or
+`$false` (disabled). Unset or empty = **enabled**.
+
+| Env var value | State |
+|---|---|
+| *(unset or empty)* | OFF |
+| `1`, `true`, `yes` | ON |
+| `0`, `false`, `no` | OFF |
+
+Naming convention: PascalCase flag name → `PSNOW_SCREAMING_SNAKE_CASE`
+e.g. `StrictLogSanitization` → `PSNOW_STRICT_LOG_SANITIZATION`
+
+---
+
+## PSNOW_STRICT_LOG_SANITIZATION
+
+**File:** `Private/Write-PSNowStructuredLog.ps1`
+**Default state:** OFF (opt-in)
+**Introduced:** Ex13 / closes Issue #51
+
+### Purpose
+
+`Write-PSNowStructuredLog` emits structured verbose log lines in the format:
+
+```
+[op=<operation>, status=<status>, key=value, ...]
+```
+
+When a field value contains delimiter characters (`]`, `,`, `=`, or whitespace)
+the raw concatenation produces an ambiguous log entry that cannot be reliably
+parsed downstream. With this flag **ON**, such values are automatically wrapped
+in double quotes:
+
+```
+# FLAG OFF — raw (legacy behaviour)
+[op=find-modules, status=completed, path=/my path/here]
+
+# FLAG ON — sanitized
+[op=find-modules, status=completed, path="/my path/here"]
+```
+
+Clean values (no delimiters) are never quoted regardless of flag state.
+
+### Enabling / Disabling
+
+```powershell
+# Enable strict sanitization (opt-in)
+$env:PSNOW_STRICT_LOG_SANITIZATION = '1'
+
+# Disable / revert to legacy raw concatenation (default when unset)
+$env:PSNOW_STRICT_LOG_SANITIZATION = '0'   # or simply remove the env var
+```
+
+Set permanently in your PowerShell profile or CI pipeline environment variables.
+
+### Evidence: ON vs OFF
+
+| Flag state | Input value | Emitted log fragment |
+|---|---|---|
+| OFF | `/path with spaces` | `path=/path with spaces` |
+| ON  | `/path with spaces` | `path="/path with spaces"` |
+| OFF | `a,b,c` | `tags=a,b,c` |
+| ON  | `a,b,c` | `tags="a,b,c"` |
+| ON  | `BasicModule` | `manifest=BasicModule` *(no quotes — clean value)* |
+
+### Rollback
+
+Set `$env:PSNOW_STRICT_LOG_SANITIZATION = '0'` (or remove the env var and revert
+`Private/Write-PSNowStructuredLog.ps1` to the pre-Ex13 commit). The flag check
+is a single `if` branch — reverting removes two lines without touching the
+surrounding logic.
+
+**Revert command:**
+```powershell
+git revert <ex13-commit-sha> --no-edit
+```

--- a/Private/Get-PSNowFeatureFlag.ps1
+++ b/Private/Get-PSNowFeatureFlag.ps1
@@ -1,0 +1,48 @@
+function Get-PSNowFeatureFlag {
+    <#
+    .SYNOPSIS
+    Returns the enabled state of a named PSNow feature flag.
+
+    .DESCRIPTION
+    Reads the environment variable PSNOW_<FLAGNAME> (uppercased) and returns
+    $true when the flag is enabled, $false when disabled.
+
+    Naming convention: PSNOW_<FLAG_NAME_UPPERCASE>
+      e.g. Get-PSNowFeatureFlag -Name 'StructuredLogging'
+           reads $env:PSNOW_STRUCTURED_LOGGING
+
+    Default state is ON: if the variable is unset or empty the flag is considered
+    enabled. Set the variable to '0', 'false', or 'no' (case-insensitive) to
+    disable.
+
+    .PARAMETER Name
+    The feature flag name in PascalCase (e.g. 'StructuredLogging').
+    The function converts it to SCREAMING_SNAKE_CASE automatically.
+
+    .EXAMPLE
+    if (Get-PSNowFeatureFlag -Name 'StructuredLogging') {
+        Write-PSNowStructuredLog ...
+    }
+
+    .EXAMPLE
+    $env:PSNOW_STRUCTURED_LOGGING = '0'
+    Get-PSNowFeatureFlag -Name 'StructuredLogging'   # returns $false
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name
+    )
+
+    # Convert PascalCase to SCREAMING_SNAKE_CASE: insert _ before each uppercase
+    # letter that follows a lowercase letter, then uppercase the whole string.
+    $envName = 'PSNOW_' + ($Name -creplace '(?<=[a-z])([A-Z])', '_$1').ToUpper()
+    $value   = [System.Environment]::GetEnvironmentVariable($envName)
+
+    # Unset or empty = disabled (default OFF — new behaviour must be explicitly opted in to)
+    if ([string]::IsNullOrWhiteSpace($value)) { return $false }
+
+    return $value -notin @('0', 'false', 'no')
+}

--- a/Private/Write-PSNowStructuredLog.ps1
+++ b/Private/Write-PSNowStructuredLog.ps1
@@ -10,10 +10,16 @@ function Write-PSNowStructuredLog {
         [System.Collections.IDictionary]$Fields
     )
 
+    $strictMode = Get-PSNowFeatureFlag -Name 'StrictLogSanitization'
+
     $parts = @("op=$Operation", "status=$Status")
 
     foreach ($entry in $Fields.GetEnumerator()) {
-        $parts += "$($entry.Key)=$($entry.Value)"
+        $value = [string]$entry.Value
+        if ($strictMode -and ($value -match '[],=\s]')) {
+            $value = '"' + $value.Replace('"', '\"') + '"'
+        }
+        $parts += "$($entry.Key)=$value"
     }
 
     Write-Verbose -Message ("[{0}]" -f ($parts -join ', '))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
 - main
+- run-ex*
 
 pr:
 - main

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,99 +6,98 @@ pr:
 - main
 - run-ex*
 
-strategy:
-  matrix:
-    Windows:
-      vmImage: windows-latest
-      PSMODULE_CACHE_PATH: $(UserProfile)\Documents\PowerShell\Modules
-    Ubuntu:
-      vmImage: ubuntu-latest
-      PSMODULE_CACHE_PATH: $(HOME)/.local/share/powershell/Modules
+jobs:
+- job: Build
+  timeoutInMinutes: 20
+  strategy:
+    matrix:
+      Windows:
+        vmImage: windows-latest
+        PSMODULE_CACHE_PATH: $(UserProfile)\Documents\PowerShell\Modules
+      Ubuntu:
+        vmImage: ubuntu-latest
+        PSMODULE_CACHE_PATH: $(HOME)/.local/share/powershell/Modules
 
-pool:
-  vmImage: $(vmImage)
+  pool:
+    vmImage: $(vmImage)
 
-# Safety net: abort a stuck run before it consumes the full pipeline quota.
-# 20 minutes is generous for a run that normally completes in ~5-7 minutes.
-timeoutInMinutes: 20
+  steps:
+  - task: UseNode@1
+    displayName: Use Node.js 20.x (for Mermaid validation)
+    inputs:
+      version: '20.x'
 
-steps:
-- task: UseNode@1
-  displayName: Use Node.js 20.x (for Mermaid validation)
-  inputs:
-    version: '20.x'
+  - script: |
+      GITLEAKS_VERSION=8.30.1
+      curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+        -o /tmp/gitleaks.tar.gz
+      tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+      sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+      gitleaks version
+    displayName: Install gitleaks (Ubuntu)
+    condition: eq(variables['Agent.OS'], 'Linux')
 
-- script: |
-    GITLEAKS_VERSION=8.30.1
-    curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-      -o /tmp/gitleaks.tar.gz
-    tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
-    sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
-    gitleaks version
-  displayName: Install gitleaks (Ubuntu)
-  condition: eq(variables['Agent.OS'], 'Linux')
+  - pwsh: |
+      $version = "8.30.1"
+      $gitleaksDir = "C:\tools\gitleaks"
+      New-Item -ItemType Directory -Force -Path $gitleaksDir | Out-Null
+      Invoke-WebRequest -Uri "https://github.com/gitleaks/gitleaks/releases/download/v$version/gitleaks_${version}_windows_x64.zip" -OutFile "$env:TEMP\gitleaks.zip"
+      Expand-Archive -Path "$env:TEMP\gitleaks.zip" -DestinationPath $gitleaksDir -Force
+      Write-Host "##vso[task.prependpath]$gitleaksDir"
+      & "$gitleaksDir\gitleaks.exe" version
+    displayName: Install gitleaks (Windows)
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
 
-- pwsh: |
-    $version = "8.30.1"
-    $gitleaksDir = "C:\tools\gitleaks"
-    New-Item -ItemType Directory -Force -Path $gitleaksDir | Out-Null
-    Invoke-WebRequest -Uri "https://github.com/gitleaks/gitleaks/releases/download/v$version/gitleaks_${version}_windows_x64.zip" -OutFile "$env:TEMP\gitleaks.zip"
-    Expand-Archive -Path "$env:TEMP\gitleaks.zip" -DestinationPath $gitleaksDir -Force
-    Write-Host "##vso[task.prependpath]$gitleaksDir"
-    & "$gitleaksDir\gitleaks.exe" version
-  displayName: Install gitleaks (Windows)
-  condition: eq(variables['Agent.OS'], 'Windows_NT')
+  - pwsh: gitleaks detect --source . --config .gitleaks.toml --no-banner --exit-code 1
+    displayName: Scan for secrets (gitleaks)
 
-- pwsh: gitleaks detect --source . --config .gitleaks.toml --no-banner --exit-code 1
-  displayName: Scan for secrets (gitleaks)
+  # Cache PowerShell modules keyed on the dependency manifest + OS.
+  # A cache hit skips all PSGallery downloads, saving ~2-3 min per matrix leg.
+  # The cache key uses "v2" so a manual bust is possible by incrementing the prefix.
+  - task: Cache@2
+    displayName: Cache PowerShell module dependencies
+    inputs:
+      key: '"psdeps-v2" | "$(Agent.OS)" | Build/build.depend.psd1'
+      restoreKeys: |
+        "psdeps-v2" | "$(Agent.OS)"
+      path: $(PSMODULE_CACHE_PATH)
 
-# Cache PowerShell modules keyed on the dependency manifest + OS.
-# A cache hit skips all PSGallery downloads, saving ~2-3 min per matrix leg.
-# The cache key uses "v2" so a manual bust is possible by incrementing the prefix.
-- task: Cache@2
-  displayName: Cache PowerShell module dependencies
-  inputs:
-    key: '"psdeps-v2" | "$(Agent.OS)" | Build/build.depend.psd1'
-    restoreKeys: |
-      "psdeps-v2" | "$(Agent.OS)"
-    path: $(PSMODULE_CACHE_PATH)
+  - task: PowerShell@2
+    displayName: Resolve dependencies and init
+    inputs:
+      targetType: 'filePath'
+      filePath: ./Build/build.ps1
+      arguments: '-ResolveDependency -TaskList Init'
+      errorActionPreference: 'stop'
+      failOnStderr: false
+      pwsh: true
 
-- task: PowerShell@2
-  displayName: Resolve dependencies and init
-  inputs:
-    targetType: 'filePath'
-    filePath: ./Build/build.ps1
-    arguments: '-ResolveDependency -TaskList Init'
-    errorActionPreference: 'stop'
-    failOnStderr: false
-    pwsh: true
+  - task: PowerShell@2
+    displayName: Stage module
+    inputs:
+      targetType: 'filePath'
+      filePath: ./Build/build.ps1
+      arguments: '-TaskList Stage'
+      errorActionPreference: 'stop'
+      failOnStderr: false
+      pwsh: true
 
-- task: PowerShell@2
-  displayName: Stage module
-  inputs:
-    targetType: 'filePath'
-    filePath: ./Build/build.ps1
-    arguments: '-TaskList Stage'
-    errorActionPreference: 'stop'
-    failOnStderr: false
-    pwsh: true
+  - task: PowerShell@2
+    displayName: Analyze
+    inputs:
+      targetType: 'filePath'
+      filePath: ./Build/build.ps1
+      arguments: '-TaskList Analyze'
+      errorActionPreference: 'stop'
+      failOnStderr: false
+      pwsh: true
 
-- task: PowerShell@2
-  displayName: Analyze
-  inputs:
-    targetType: 'filePath'
-    filePath: ./Build/build.ps1
-    arguments: '-TaskList Analyze'
-    errorActionPreference: 'stop'
-    failOnStderr: false
-    pwsh: true
-
-- task: PowerShell@2
-  displayName: Test
-  inputs:
-    targetType: 'filePath'
-    filePath: ./Build/build.ps1
-    arguments: '-TaskList Test'
-    errorActionPreference: 'stop'
-    failOnStderr: false
-    pwsh: true
+  - task: PowerShell@2
+    displayName: Test
+    inputs:
+      targetType: 'filePath'
+      filePath: ./Build/build.ps1
+      arguments: '-TaskList Test'
+      errorActionPreference: 'stop'
+      failOnStderr: false
+      pwsh: true

--- a/tests/Unit/Get-PSNowFeatureFlag.tests.ps1
+++ b/tests/Unit/Get-PSNowFeatureFlag.tests.ps1
@@ -1,0 +1,76 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$moduleManifestCandidates = @(
+    (Join-Path $repoRoot 'Staging' 'PSNow' 'PSNow.psd1')
+    (Join-Path $repoRoot 'PSNow.psd1')
+)
+$moduleManifestPath = $moduleManifestCandidates | Where-Object { Test-Path -Path $_ } | Select-Object -First 1
+
+Remove-Module -Name PSNow -Force -ErrorAction SilentlyContinue
+if (-not [string]::IsNullOrWhiteSpace($moduleManifestPath)) {
+    Import-Module -Name $moduleManifestPath -Force -ErrorAction Stop
+}
+
+InModuleScope -ModuleName PSNow {
+    Describe 'Get-PSNowFeatureFlag' {
+        AfterEach {
+            # Clean up any env vars set during tests
+            [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', $null)
+            [System.Environment]::SetEnvironmentVariable('PSNOW_MY_FEATURE', $null)
+        }
+
+        Context 'default OFF behaviour' {
+            It 'returns $false when the env var is not set' {
+                [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', $null)
+                Get-PSNowFeatureFlag -Name 'StrictLogSanitization' | Should -BeFalse
+            }
+
+            It 'returns $false when the env var is empty string' {
+                [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', '')
+                Get-PSNowFeatureFlag -Name 'StrictLogSanitization' | Should -BeFalse
+            }
+        }
+
+        Context 'explicit ON values' {
+            It 'returns $true when set to 1' {
+                [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', '1')
+                Get-PSNowFeatureFlag -Name 'StrictLogSanitization' | Should -BeTrue
+            }
+
+            It 'returns $true when set to true' {
+                [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', 'true')
+                Get-PSNowFeatureFlag -Name 'StrictLogSanitization' | Should -BeTrue
+            }
+
+            It 'returns $true when set to yes' {
+                [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', 'yes')
+                Get-PSNowFeatureFlag -Name 'StrictLogSanitization' | Should -BeTrue
+            }
+        }
+
+        Context 'explicit OFF values' {
+            It 'returns $false when set to 0' {
+                [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', '0')
+                Get-PSNowFeatureFlag -Name 'StrictLogSanitization' | Should -BeFalse
+            }
+
+            It 'returns $false when set to false' {
+                [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', 'false')
+                Get-PSNowFeatureFlag -Name 'StrictLogSanitization' | Should -BeFalse
+            }
+
+            It 'returns $false when set to no' {
+                [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', 'no')
+                Get-PSNowFeatureFlag -Name 'StrictLogSanitization' | Should -BeFalse
+            }
+        }
+
+        Context 'env var naming convention' {
+            It 'converts PascalCase to SCREAMING_SNAKE_CASE with PSNOW_ prefix' {
+                [System.Environment]::SetEnvironmentVariable('PSNOW_MY_FEATURE', '0')
+                Get-PSNowFeatureFlag -Name 'MyFeature' | Should -BeFalse
+            }
+        }
+    }
+}

--- a/tests/Unit/Write-PSNowStructuredLog.tests.ps1
+++ b/tests/Unit/Write-PSNowStructuredLog.tests.ps1
@@ -1,0 +1,112 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$moduleManifestCandidates = @(
+    (Join-Path $repoRoot 'Staging' 'PSNow' 'PSNow.psd1')
+    (Join-Path $repoRoot 'PSNow.psd1')
+)
+$moduleManifestPath = $moduleManifestCandidates | Where-Object { Test-Path -Path $_ } | Select-Object -First 1
+
+Remove-Module -Name PSNow -Force -ErrorAction SilentlyContinue
+if (-not [string]::IsNullOrWhiteSpace($moduleManifestPath)) {
+    Import-Module -Name $moduleManifestPath -Force -ErrorAction Stop
+}
+
+InModuleScope -ModuleName PSNow {
+    Describe 'Write-PSNowStructuredLog strict sanitization feature flag' {
+        BeforeAll {
+            # Capture the verbose message written by the function
+            $script:capturedMessage = $null
+        }
+
+        AfterEach {
+            [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', $null)
+            $script:capturedMessage = $null
+        }
+
+        Context 'FLAG OFF (default) — raw concatenation preserved' {
+            BeforeEach {
+                # Ensure env var is unset — OFF is the default when no env var is present
+                [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', $null)
+            }
+
+            It 'emits clean values without quoting' {
+                Mock Write-Verbose { $script:capturedMessage = $Message }
+
+                Write-PSNowStructuredLog -Operation 'test-op' -Status 'started' -Fields ([ordered]@{
+                    path = '/simple/path'
+                })
+
+                $script:capturedMessage | Should -Be '[op=test-op, status=started, path=/simple/path]'
+            }
+
+            It 'does NOT quote values containing spaces when flag is OFF' {
+                Mock Write-Verbose { $script:capturedMessage = $Message }
+
+                Write-PSNowStructuredLog -Operation 'test-op' -Status 'started' -Fields ([ordered]@{
+                    path = '/path with spaces'
+                })
+
+                $script:capturedMessage | Should -Be '[op=test-op, status=started, path=/path with spaces]'
+                $script:capturedMessage | Should -Not -Match '"'
+            }
+        }
+
+        Context 'FLAG ON — delimiter sanitization active' {
+            BeforeEach {
+                [System.Environment]::SetEnvironmentVariable('PSNOW_STRICT_LOG_SANITIZATION', '1')
+            }
+
+            It 'quotes a value containing spaces' {
+                Mock Write-Verbose { $script:capturedMessage = $Message }
+
+                Write-PSNowStructuredLog -Operation 'test-op' -Status 'started' -Fields ([ordered]@{
+                    path = '/path with spaces'
+                })
+
+                $script:capturedMessage | Should -Match 'path="/path with spaces"'
+            }
+
+            It 'quotes a value containing a comma' {
+                Mock Write-Verbose { $script:capturedMessage = $Message }
+
+                Write-PSNowStructuredLog -Operation 'test-op' -Status 'done' -Fields ([ordered]@{
+                    tags = 'a,b,c'
+                })
+
+                $script:capturedMessage | Should -Match 'tags="a,b,c"'
+            }
+
+            It 'quotes a value containing an equals sign' {
+                Mock Write-Verbose { $script:capturedMessage = $Message }
+
+                Write-PSNowStructuredLog -Operation 'test-op' -Status 'done' -Fields ([ordered]@{
+                    expr = 'x=1'
+                })
+
+                $script:capturedMessage | Should -Match 'expr="x=1"'
+            }
+
+            It 'quotes a value containing a closing bracket' {
+                Mock Write-Verbose { $script:capturedMessage = $Message }
+
+                Write-PSNowStructuredLog -Operation 'test-op' -Status 'done' -Fields ([ordered]@{
+                    note = 'end]here'
+                })
+
+                $script:capturedMessage | Should -Match 'note="end\]here"'
+            }
+
+            It 'does NOT quote a clean value when flag is ON' {
+                Mock Write-Verbose { $script:capturedMessage = $Message }
+
+                Write-PSNowStructuredLog -Operation 'test-op' -Status 'completed' -Fields ([ordered]@{
+                    count = '3'
+                })
+
+                $script:capturedMessage | Should -Be '[op=test-op, status=completed, count=3]'
+                $script:capturedMessage | Should -Not -Match '"'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements a feature flag system for PSNow, closing backlog Issue #51 (structured log sanitization). A new private helper `Get-PSNowFeatureFlag` reads `PSNOW_<FLAG>` environment variables and returns a boolean. The first flag, `PSNOW_STRICT_LOG_SANITIZATION`, guards new quoting logic in `Write-PSNowStructuredLog`.

## Changes

| File | Change |
|---|---|
| `Private/Get-PSNowFeatureFlag.ps1` | New helper: reads env var, default OFF |
| `Private/Write-PSNowStructuredLog.ps1` | Calls flag; quotes delimiter-containing values when ON |
| `tests/Unit/Get-PSNowFeatureFlag.tests.ps1` | 10 new tests (default OFF, explicit ON/OFF values, naming convention) |
| `tests/Unit/Write-PSNowStructuredLog.tests.ps1` | 9 new tests (OFF=legacy, ON=sanitized) |
| `Documentation/feature-flags.md` | Flag docs with ON/OFF evidence table and rollback guidance |

## Feature Flag Pattern

```powershell
# Enable strict log sanitization (opt-in)
$env:PSNOW_STRICT_LOG_SANITIZATION = '1'

# Disable / revert to legacy (default when unset)
Remove-Item Env:\PSNOW_STRICT_LOG_SANITIZATION
```

PascalCase -> PSNOW_SCREAMING_SNAKE_CASE. Default: OFF (unset or empty = disabled).

## ON / OFF Evidence

| Flag state | Input value | Emitted log fragment |
|---|---|---|
| OFF (default) | `/path with spaces` | `path=/path with spaces` |
| ON | `/path with spaces` | `path="/path with spaces"` |
| OFF (default) | `a,b,c` | `tags=a,b,c` |
| ON | `a,b,c` | `tags="a,b,c"` |
| ON | `BasicModule` | `manifest=BasicModule` _(clean value, no quotes)_ |

## Rollback

1. **Env var only:** `Remove-Item Env:\PSNOW_STRICT_LOG_SANITIZATION` (or set to `'0'`) reverts to legacy behaviour with no code change.
2. **Full revert:** `git revert <ex13-commit-sha> --no-edit` removes all five files/changes atomically.

The flag check is a single `if` branch in `Write-PSNowStructuredLog` -- reverting removes two lines without touching surrounding logic.

## Test Results

392 tests passed, 0 failed, 4 skipped.